### PR TITLE
feat: rebuild as core-lib + plugin monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.db
+test-report.html
+.cache/
+bun.lockb

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "flaky-tests",
+  "version": "0.1.0",
+  "private": true,
+  "workspaces": ["packages/*"],
+  "scripts": {
+    "test": "bun test"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@flaky-tests/core",
+  "version": "0.1.0",
+  "description": "Storage-agnostic core types and utilities for flaky-tests",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "license": "MIT"
+}

--- a/packages/core/src/categorize.ts
+++ b/packages/core/src/categorize.ts
@@ -1,0 +1,51 @@
+import type { FailureKind } from './types'
+
+/**
+ * Classifies a thrown test error into a coarse category. The categories are
+ * deliberately few — we want to answer "is this test timing out vs. a bad
+ * assertion vs. an uncaught crash" at a glance.
+ *
+ * Ordering matters: a timeout thrown as an AssertionError should classify as
+ * `timeout` — the timeout signal is more useful for flakiness analysis.
+ */
+export function categorizeError(error: unknown): FailureKind {
+  if (!(error instanceof Error)) {
+    return 'unknown'
+  }
+  const message = error.message ?? ''
+  if (error.name === 'TimeoutError' || /timed? ?out/i.test(message)) {
+    return 'timeout'
+  }
+  if (
+    error.name === 'AssertionError' ||
+    // Bun's `expect` attaches a `matcherResult` to failures
+    'matcherResult' in error ||
+    // Vitest / Jest expect error format
+    message.startsWith('expect(received)')
+  ) {
+    return 'assertion'
+  }
+  return 'uncaught'
+}
+
+/**
+ * Extracts a message string from a thrown value, coercing non-Error throws
+ * to their string representation.
+ */
+export function extractMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error)
+}
+
+/**
+ * Extracts a stack string from a thrown value. Returns `null` for non-Error
+ * throws that have no stack.
+ */
+export function extractStack(error: unknown): string | null {
+  if (error instanceof Error && typeof error.stack === 'string') {
+    return error.stack
+  }
+  return null
+}

--- a/packages/core/src/describe-stack.ts
+++ b/packages/core/src/describe-stack.ts
@@ -1,0 +1,59 @@
+/**
+ * Tracks the current `describe` nesting so tests report their full
+ * `"outer > inner > test name"` path.
+ *
+ * Used by the Bun preload which must monkey-patch `describe` to track nesting.
+ * Vitest and other frameworks expose suite paths natively.
+ */
+export class DescribeStack {
+  private frames: string[] = []
+
+  /**
+   * Snapshot of the current frames. Used by the `describe` wrapper to capture
+   * the path at describe-call time (synchronous w.r.t. the outer body), then
+   * replay it via `runWithFrames` whenever the runtime executes the nested body.
+   */
+  get snapshot(): readonly string[] {
+    return this.frames
+  }
+
+  /**
+   * Runs `body` with `name` pushed onto the stack. Pop is guaranteed by
+   * try/finally so a thrown describe body does not leave a dangling frame.
+   */
+  run<T>(name: string, body: () => T): T {
+    this.frames.push(name)
+    try {
+      return body()
+    } finally {
+      this.frames.pop()
+    }
+  }
+
+  /**
+   * Runs `body` with the stack temporarily replaced by `frames` (absolute,
+   * not appended). Used to restore a describe-path captured at registration
+   * time, since Bun defers nested describe body execution.
+   */
+  runWithFrames<T>(frames: readonly string[], body: () => T): T {
+    const saved = this.frames
+    this.frames = [...frames]
+    try {
+      return body()
+    } finally {
+      this.frames = saved
+    }
+  }
+
+  /** Returns the full path for a test, joined by ` > `. */
+  path(testName: string): string {
+    if (this.frames.length === 0) {
+      return testName
+    }
+    return `${this.frames.join(' > ')} > ${testName}`
+  }
+
+  get depth(): number {
+    return this.frames.length
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,9 @@
+export type {
+  FailureKind,
+  InsertRunInput,
+  UpdateRunInput,
+  InsertFailureInput,
+  IStore,
+} from './types'
+export { categorizeError, extractMessage, extractStack } from './categorize'
+export { DescribeStack } from './describe-stack'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,42 @@
+export type FailureKind = 'assertion' | 'timeout' | 'uncaught' | 'unknown'
+
+export interface InsertRunInput {
+  runId: string
+  startedAt: string
+  gitSha?: string | null
+  gitDirty?: boolean | null
+  runtimeVersion?: string | null
+  testArgs?: string | null
+}
+
+export interface UpdateRunInput {
+  endedAt?: string
+  durationMs?: number
+  status?: 'pass' | 'fail'
+  totalTests?: number
+  passedTests?: number
+  failedTests?: number
+  errorsBetweenTests?: number
+}
+
+export interface InsertFailureInput {
+  runId: string
+  testFile: string
+  testName: string
+  failureKind: FailureKind
+  errorMessage?: string | null
+  errorStack?: string | null
+  durationMs?: number | null
+  failedAt: string
+}
+
+/**
+ * Storage backend interface. All methods are async so implementations can
+ * use any backend — SQLite, Supabase, Postgres, or custom.
+ */
+export interface IStore {
+  insertRun(input: InsertRunInput): Promise<void>
+  updateRun(runId: string, input: UpdateRunInput): Promise<void>
+  insertFailure(input: InsertFailureInput): Promise<void>
+  close(): Promise<void>
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/plugin-bun/package.json
+++ b/packages/plugin-bun/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@flaky-tests/plugin-bun",
+  "version": "0.1.0",
+  "description": "Bun test preload plugin for flaky-tests",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./preload": "./src/preload-sqlite.ts",
+    "./run-tracked": "./src/run-tracked.ts"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@flaky-tests/core": "workspace:*",
+    "@flaky-tests/store-sqlite": "workspace:*"
+  },
+  "devDependencies": {
+    "bun-types": "latest"
+  },
+  "engines": {
+    "bun": ">=1.3.0"
+  }
+}

--- a/packages/plugin-bun/src/git.ts
+++ b/packages/plugin-bun/src/git.ts
@@ -1,0 +1,28 @@
+export interface GitInfo {
+  sha: string | null
+  dirty: boolean | null
+}
+
+function runGit(args: string[]): string | null {
+  try {
+    const result = Bun.spawnSync({
+      cmd: ['git', ...args],
+      stdout: 'pipe',
+      stderr: 'ignore',
+    })
+    if (result.exitCode !== 0) return null
+    return new TextDecoder().decode(result.stdout)
+  } catch {
+    return null
+  }
+}
+
+export function captureGitInfo(): GitInfo {
+  const sha = runGit(['rev-parse', 'HEAD'])
+  const porcelain = runGit(['status', '--porcelain'])
+  if (sha === null) return { sha: null, dirty: null }
+  return {
+    sha: sha.trim(),
+    dirty: porcelain !== null && porcelain.trim().length > 0,
+  }
+}

--- a/packages/plugin-bun/src/index.ts
+++ b/packages/plugin-bun/src/index.ts
@@ -1,0 +1,3 @@
+export { createPreload } from './preload'
+export type { GitInfo } from './git'
+export { captureGitInfo } from './git'

--- a/packages/plugin-bun/src/preload-sqlite.ts
+++ b/packages/plugin-bun/src/preload-sqlite.ts
@@ -1,0 +1,29 @@
+/**
+ * Default Bun preload — uses the SQLite store.
+ *
+ * Configure in bunfig.toml:
+ *
+ *   [test]
+ *   preload = ["@flaky-tests/plugin-bun/preload"]
+ *
+ * Environment variables:
+ *   FLAKY_TESTS_DISABLE=1   — skip all telemetry
+ *   FLAKY_TESTS_DB=<path>   — override DB path
+ *   FLAKY_TESTS_RUN_ID=<id> — set by run-tracked for reconciliation
+ */
+
+// biome-ignore-all lint/suspicious/noConsole: preload is dev tooling
+
+import { SqliteStore } from '@flaky-tests/store-sqlite'
+import { createPreload } from './preload'
+
+if (process.env.FLAKY_TESTS_DISABLE !== '1') {
+  try {
+    const store = new SqliteStore({
+      dbPath: process.env.FLAKY_TESTS_DB ?? undefined,
+    })
+    createPreload(store)
+  } catch (error) {
+    console.warn('[flaky-tests] Failed to initialise preload:', error)
+  }
+}

--- a/packages/plugin-bun/src/preload.ts
+++ b/packages/plugin-bun/src/preload.ts
@@ -1,0 +1,214 @@
+/**
+ * Core Bun preload logic. Monkey-patches `bun:test` so every test/it/describe
+ * call records failures to the provided IStore.
+ *
+ * Most users should use the default `@flaky-tests/plugin-bun/preload` export
+ * which wires this up to a SQLite store automatically.
+ *
+ * For custom stores (Supabase, Postgres, etc.) create your own preload file:
+ *
+ *   // my-preload.ts
+ *   import { createPreload } from '@flaky-tests/plugin-bun'
+ *   import { SupabaseStore } from '@flaky-tests/store-supabase'
+ *
+ *   createPreload(new SupabaseStore({ url: '...', key: '...' }))
+ *
+ * Then in bunfig.toml:
+ *
+ *   [test]
+ *   preload = ["./my-preload.ts"]
+ */
+
+// biome-ignore-all lint/suspicious/noConsole: preload is dev tooling
+
+import * as bunTest from 'bun:test'
+import { afterAll, mock } from 'bun:test'
+import type { IStore } from '@flaky-tests/core'
+import { categorizeError, DescribeStack, extractMessage, extractStack } from '@flaky-tests/core'
+import { captureGitInfo } from './git'
+
+type TestCallback = (...args: unknown[]) => unknown | Promise<unknown>
+type TestFn = (name: string, fn: TestCallback, timeout?: number) => unknown
+type DescribeFn = (name: string, body: () => void) => unknown
+
+/** Fire-and-forget an async side-effect that must never throw into the caller. */
+function safeVoid(label: string, effect: () => Promise<void>): void {
+  effect().catch((error: unknown) => console.warn(`[flaky-tests] ${label}:`, error))
+}
+
+/**
+ * Resolves the test source file from a thrown error's stack by finding the
+ * first frame that isn't inside this package. Falls back to `'unknown'`.
+ */
+function resolveTestFile(error: unknown): string {
+  if (!(error instanceof Error) || typeof error.stack !== 'string') return 'unknown'
+  for (const line of error.stack.split('\n')) {
+    const match = line.match(/\(([^)]+\.(?:ts|tsx|js|jsx|mjs|cjs)):\d+:\d+\)/)
+    if (!match) continue
+    const file = match[1] ?? ''
+    if (file.includes('/plugin-bun/')) continue
+    return file
+  }
+  return 'unknown'
+}
+
+export function createPreload(store: IStore): void {
+  // Use a run id provided by run-tracked (so it can reconcile the row post-exit)
+  // or generate a fresh one.
+  const providedRunId = process.env.FLAKY_TESTS_RUN_ID
+  const runId =
+    providedRunId !== undefined && providedRunId.length > 0
+      ? providedRunId
+      : crypto.randomUUID()
+  const startedAt = new Date().toISOString()
+  const startPerf = performance.now()
+  const git = captureGitInfo()
+
+  safeVoid('insertRun', () =>
+    store.insertRun({
+      runId,
+      startedAt,
+      gitSha: git.sha,
+      gitDirty: git.dirty,
+      runtimeVersion: Bun.version,
+      testArgs: process.argv.slice(2).join(' '),
+    }),
+  )
+
+  let testsRun = 0
+  let testsFailed = 0
+  let errorsBetweenTests = 0
+  const describeStack = new DescribeStack()
+
+  // Errors escaping test wrappers — unhandled rejections, module-load throws.
+  const onRunLevelError = (error: unknown): void => {
+    errorsBetweenTests++
+    safeVoid('insertFailure (between-tests)', () =>
+      store.insertFailure({
+        runId,
+        testFile: resolveTestFile(error),
+        testName: '<between tests>',
+        failureKind: categorizeError(error),
+        errorMessage: extractMessage(error),
+        errorStack: extractStack(error),
+        durationMs: 0,
+        failedAt: new Date().toISOString(),
+      }),
+    )
+  }
+  process.on('uncaughtException', onRunLevelError)
+  process.on('unhandledRejection', onRunLevelError)
+
+  const recordFailure = (opts: {
+    testFile: string
+    testName: string
+    error: unknown
+    durationMs: number
+  }): void => {
+    safeVoid('insertFailure', () =>
+      store.insertFailure({
+        runId,
+        testFile: opts.testFile,
+        testName: opts.testName,
+        failureKind: categorizeError(opts.error),
+        errorMessage: extractMessage(opts.error),
+        errorStack: extractStack(opts.error),
+        durationMs: Math.round(opts.durationMs),
+        failedAt: new Date().toISOString(),
+      }),
+    )
+  }
+
+  // Proxy-based wrapping so sub-APIs like .each, .skip, .only, .todo etc.
+  // keep working — they live on the prototype chain, not as own properties.
+  const wrapTest = (originalTest: TestFn): TestFn => {
+    const callWrapped: TestFn = (name, fn, timeout) => {
+      // Preserve `done`-callback style — wrapping would change arity and
+      // trigger Bun's async-done timeout.
+      if (fn.length > 0) return originalTest(name, fn, timeout)
+
+      const fullPath = describeStack.path(name)
+      const wrappedFn: TestCallback = async () => {
+        testsRun++
+        const t0 = performance.now()
+        try {
+          await fn()
+        } catch (error) {
+          testsFailed++
+          recordFailure({
+            testFile: resolveTestFile(error),
+            testName: fullPath,
+            error,
+            durationMs: performance.now() - t0,
+          })
+          throw error
+        }
+      }
+      return originalTest(name, wrappedFn, timeout)
+    }
+    return new Proxy(originalTest, {
+      apply: (_t, _th, args) =>
+        callWrapped(args[0] as string, args[1] as TestCallback, args[2] as number | undefined),
+      // Forward property access (.each, .skip, ...) to the original.
+      // Bun's sub-APIs have strict `this` validation — bind to the real target.
+      get: (target, prop) => {
+        const value = Reflect.get(target, prop, target)
+        return typeof value === 'function' ? value.bind(target) : value
+      },
+    }) as TestFn
+  }
+
+  const wrapDescribe = (originalDescribe: DescribeFn): DescribeFn => {
+    const callWrapped: DescribeFn = (name, body) => {
+      // Capture path synchronously — Bun defers nested describe body execution
+      // past the point where the outer frame is still on the live stack.
+      const capturedFrames = [...describeStack.snapshot, name]
+      return originalDescribe(name, () =>
+        describeStack.runWithFrames(capturedFrames, body),
+      )
+    }
+    return new Proxy(originalDescribe, {
+      apply: (_t, _th, args) =>
+        callWrapped(args[0] as string, args[1] as () => void),
+      get: (target, prop) => {
+        const value = Reflect.get(target, prop, target)
+        return typeof value === 'function' ? value.bind(target) : value
+      },
+    }) as DescribeFn
+  }
+
+  try {
+    mock.module('bun:test', () => ({
+      ...bunTest,
+      test: wrapTest(bunTest.test as unknown as TestFn),
+      it: wrapTest(bunTest.it as unknown as TestFn),
+      describe: wrapDescribe(bunTest.describe as unknown as DescribeFn),
+    }))
+  } catch (error) {
+    console.warn('[flaky-tests] monkey-patch bun:test failed:', error)
+  }
+
+  afterAll(async () => {
+    const endedAt = new Date().toISOString()
+    const durationMs = Math.round(performance.now() - startPerf)
+    const passedTests = testsRun - testsFailed
+    const status: 'pass' | 'fail' =
+      testsFailed > 0 || errorsBetweenTests > 0 ? 'fail' : 'pass'
+
+    await store
+      .updateRun(runId, {
+        endedAt,
+        durationMs,
+        status,
+        totalTests: testsRun,
+        passedTests,
+        failedTests: testsFailed,
+        errorsBetweenTests,
+      })
+      .catch((e: unknown) => console.warn('[flaky-tests] updateRun failed:', e))
+
+    await store
+      .close()
+      .catch((e: unknown) => console.warn('[flaky-tests] close failed:', e))
+  })
+}

--- a/packages/plugin-bun/src/run-tracked.ts
+++ b/packages/plugin-bun/src/run-tracked.ts
@@ -1,0 +1,58 @@
+/**
+ * Authoritative test runner — spawns `bun test` as a subprocess so the real
+ * exit code is observable from outside the test process.
+ *
+ * This addresses the limitation where module-load errors (TypeError at
+ * describe-registration time) are reported by Bun but invisible to any
+ * in-process observer. The exit code is the only authoritative signal.
+ *
+ * Usage:
+ *   bun run @flaky-tests/plugin-bun/run-tracked [bun-test-args...]
+ *
+ * On non-zero exit, if the preload recorded status='pass', the run is
+ * reconciled to 'fail' and errors_between_tests is incremented.
+ */
+
+// biome-ignore-all lint/suspicious/noConsole: CLI wrapper
+
+import { SqliteStore } from '@flaky-tests/store-sqlite'
+
+const DB_PATH = process.env.FLAKY_TESTS_DB ?? 'node_modules/.cache/flaky-tests/failures.db'
+
+async function main(): Promise<number> {
+  const runId = crypto.randomUUID()
+  const forwardedArgs = process.argv.slice(2)
+
+  const child = Bun.spawn({
+    cmd: ['bun', 'test', ...forwardedArgs],
+    env: { ...process.env, FLAKY_TESTS_RUN_ID: runId },
+    stdout: 'inherit',
+    stderr: 'inherit',
+    stdin: 'inherit',
+  })
+  const exitCode = await child.exited
+
+  if (exitCode !== 0) {
+    await reconcileRun(runId)
+  }
+  return exitCode
+}
+
+async function reconcileRun(runId: string): Promise<void> {
+  try {
+    if (!(await Bun.file(DB_PATH).exists())) {
+      // DB doesn't exist — preload never ran or a different path is in use.
+      return
+    }
+    const store = new SqliteStore({ dbPath: DB_PATH })
+    try {
+      store.reconcileRun(runId)
+    } finally {
+      await store.close()
+    }
+  } catch (error) {
+    console.warn('[flaky-tests] reconcile failed:', error)
+  }
+}
+
+process.exit(await main())

--- a/packages/plugin-bun/tsconfig.json
+++ b/packages/plugin-bun/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/plugin-vitest/package.json
+++ b/packages/plugin-vitest/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@flaky-tests/plugin-vitest",
+  "version": "0.1.0",
+  "description": "Vitest reporter plugin for flaky-tests",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@flaky-tests/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "vitest": ">=1.0.0"
+  }
+}

--- a/packages/plugin-vitest/src/index.ts
+++ b/packages/plugin-vitest/src/index.ts
@@ -1,0 +1,172 @@
+/**
+ * Vitest reporter for flaky-tests.
+ *
+ * Usage in vitest.config.ts:
+ *
+ *   import { FlakyTestsReporter } from '@flaky-tests/plugin-vitest'
+ *   import { SqliteStore } from '@flaky-tests/store-sqlite'
+ *   // or: import { SupabaseStore } from '@flaky-tests/store-supabase'
+ *   // or: import { PostgresStore } from '@flaky-tests/store-postgres'
+ *
+ *   export default defineConfig({
+ *     test: {
+ *       reporters: [
+ *         'default',
+ *         new FlakyTestsReporter(new SqliteStore()),
+ *       ],
+ *     },
+ *   })
+ */
+
+// biome-ignore-all lint/suspicious/noConsole: reporter is dev tooling
+
+import { execSync } from 'node:child_process'
+import type { IStore, InsertFailureInput } from '@flaky-tests/core'
+import { categorizeError, extractMessage, extractStack } from '@flaky-tests/core'
+
+interface GitInfo {
+  sha: string | null
+  dirty: boolean | null
+}
+
+function captureGitInfo(): GitInfo {
+  try {
+    const sha = execSync('git rev-parse HEAD', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim()
+    const status = execSync('git status --porcelain', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    return { sha, dirty: status.trim().length > 0 }
+  } catch {
+    return { sha: null, dirty: null }
+  }
+}
+
+// Minimal task-shape typings that work across Vitest 1.x / 2.x / 3.x.
+interface TaskResult {
+  state?: string
+  errors?: unknown[]
+  duration?: number
+}
+
+interface TaskBase {
+  id: string
+  name: string
+  type: string
+  result?: TaskResult
+  file?: { filepath: string }
+  suite?: TaskBase
+  tasks?: TaskBase[]
+}
+
+function getTestPath(task: TaskBase): string {
+  const parts: string[] = [task.name]
+  let current = task.suite
+  while (current && current.type === 'suite') {
+    parts.unshift(current.name)
+    current = current.suite
+  }
+  return parts.join(' > ')
+}
+
+function walkTasks(tasks: TaskBase[], visit: (task: TaskBase) => void): void {
+  for (const task of tasks) {
+    visit(task)
+    if (task.tasks) walkTasks(task.tasks, visit)
+  }
+}
+
+export class FlakyTestsReporter {
+  private store: IStore
+  private runId: string = crypto.randomUUID()
+  private startTime: number = performance.now()
+  private ready = false
+
+  constructor(store: IStore) {
+    this.store = store
+  }
+
+  /** Called once when Vitest initialises. */
+  async onInit(_ctx: unknown): Promise<void> {
+    this.ready = true
+    const git = captureGitInfo()
+    await this.store
+      .insertRun({
+        runId: this.runId,
+        startedAt: new Date().toISOString(),
+        gitSha: git.sha,
+        gitDirty: git.dirty,
+        runtimeVersion: process.version,
+        testArgs: process.argv.slice(2).join(' '),
+      })
+      .catch((e: unknown) => console.warn('[flaky-tests] insertRun failed:', e))
+  }
+
+  /**
+   * Called after all test files have finished. Collects failures from the
+   * completed file list and writes the final run record.
+   *
+   * Note: in watch mode this fires after each re-run. Each re-run produces a
+   * new run row (run_id is stable per reporter instance, so subsequent reruns
+   * overwrite the same row — create a new reporter instance per run if you
+   * want separate rows).
+   */
+  async onFinished(files: TaskBase[] = [], errors: unknown[] = []): Promise<void> {
+    if (!this.ready) return
+
+    let totalTests = 0
+    let passedTests = 0
+    let failedTests = 0
+    const failureInputs: InsertFailureInput[] = []
+
+    for (const file of files) {
+      walkTasks(file.tasks ?? [], (task) => {
+        if (task.type !== 'test' && task.type !== 'custom') return
+        const result = task.result
+        if (!result) return
+        totalTests++
+        if (result.state === 'pass') passedTests++
+        if (result.state === 'fail') {
+          failedTests++
+          const firstError = (result.errors ?? [])[0]
+          failureInputs.push({
+            runId: this.runId,
+            testFile: task.file?.filepath ?? 'unknown',
+            testName: getTestPath(task),
+            failureKind: categorizeError(firstError),
+            errorMessage: firstError != null ? extractMessage(firstError) : null,
+            errorStack: firstError != null ? extractStack(firstError) : null,
+            durationMs:
+              result.duration != null ? Math.round(result.duration) : null,
+            failedAt: new Date().toISOString(),
+          })
+        }
+      })
+    }
+
+    for (const failure of failureInputs) {
+      await this.store
+        .insertFailure(failure)
+        .catch((e: unknown) => console.warn('[flaky-tests] insertFailure failed:', e))
+    }
+
+    await this.store
+      .updateRun(this.runId, {
+        endedAt: new Date().toISOString(),
+        durationMs: Math.round(performance.now() - this.startTime),
+        status: failedTests > 0 || errors.length > 0 ? 'fail' : 'pass',
+        totalTests,
+        passedTests,
+        failedTests,
+        errorsBetweenTests: errors.length,
+      })
+      .catch((e: unknown) => console.warn('[flaky-tests] updateRun failed:', e))
+
+    await this.store
+      .close()
+      .catch((e: unknown) => console.warn('[flaky-tests] close failed:', e))
+  }
+}

--- a/packages/plugin-vitest/tsconfig.json
+++ b/packages/plugin-vitest/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/store-postgres/package.json
+++ b/packages/store-postgres/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@flaky-tests/store-postgres",
+  "version": "0.1.0",
+  "description": "PostgreSQL store adapter for flaky-tests",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@flaky-tests/core": "workspace:*",
+    "postgres": "^3.4.0"
+  }
+}

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -1,0 +1,94 @@
+import postgres from 'postgres'
+import type {
+  InsertFailureInput,
+  InsertRunInput,
+  IStore,
+  UpdateRunInput,
+} from '@flaky-tests/core'
+
+export interface PostgresStoreOptions {
+  /** Full connection string, e.g. postgres://user:pass@host:5432/db */
+  connectionString?: string
+  host?: string
+  port?: number
+  database?: string
+  username?: string
+  password?: string
+  ssl?: boolean | 'require' | 'prefer' | 'allow'
+  /**
+   * Table name prefix. Defaults to `flaky_test`, producing tables
+   * `flaky_test_runs` and `flaky_test_failures`.
+   */
+  tablePrefix?: string
+}
+
+export class PostgresStore implements IStore {
+  private sql: ReturnType<typeof postgres>
+  private runsTable: string
+  private failuresTable: string
+
+  constructor(options: PostgresStoreOptions = {}) {
+    const prefix = options.tablePrefix ?? 'flaky_test'
+    this.runsTable = `${prefix}_runs`
+    this.failuresTable = `${prefix}_failures`
+
+    if (options.connectionString) {
+      this.sql = postgres(options.connectionString)
+    } else {
+      this.sql = postgres({
+        host: options.host ?? 'localhost',
+        port: options.port ?? 5432,
+        database: options.database,
+        username: options.username,
+        password: options.password,
+        ssl: options.ssl,
+      })
+    }
+  }
+
+  async insertRun(input: InsertRunInput): Promise<void> {
+    const runs = this.runsTable
+    await this.sql`
+      INSERT INTO ${this.sql(runs)}
+        (run_id, started_at, git_sha, git_dirty, runtime_version, test_args)
+      VALUES
+        (${input.runId}, ${input.startedAt}, ${input.gitSha ?? null},
+         ${input.gitDirty ?? null}, ${input.runtimeVersion ?? null},
+         ${input.testArgs ?? null})
+    `
+  }
+
+  async updateRun(runId: string, input: UpdateRunInput): Promise<void> {
+    const runs = this.runsTable
+    await this.sql`
+      UPDATE ${this.sql(runs)} SET
+        ended_at             = ${input.endedAt ?? null},
+        duration_ms          = ${input.durationMs ?? null},
+        status               = ${input.status ?? null},
+        total_tests          = ${input.totalTests ?? null},
+        passed_tests         = ${input.passedTests ?? null},
+        failed_tests         = ${input.failedTests ?? null},
+        errors_between_tests = ${input.errorsBetweenTests ?? null}
+      WHERE run_id = ${runId}
+    `
+  }
+
+  async insertFailure(input: InsertFailureInput): Promise<void> {
+    const failures = this.failuresTable
+    await this.sql`
+      INSERT INTO ${this.sql(failures)}
+        (run_id, test_file, test_name, failure_kind,
+         error_message, error_stack, duration_ms, failed_at)
+      VALUES
+        (${input.runId}, ${input.testFile}, ${input.testName},
+         ${input.failureKind}, ${input.errorMessage ?? null},
+         ${input.errorStack ?? null},
+         ${input.durationMs != null ? Math.round(input.durationMs) : null},
+         ${input.failedAt})
+    `
+  }
+
+  async close(): Promise<void> {
+    await this.sql.end()
+  }
+}

--- a/packages/store-postgres/src/schema.sql
+++ b/packages/store-postgres/src/schema.sql
@@ -1,0 +1,33 @@
+-- Run this against your PostgreSQL database to create the required tables.
+
+CREATE TABLE IF NOT EXISTS flaky_test_runs (
+  run_id                TEXT PRIMARY KEY,
+  started_at            TIMESTAMPTZ NOT NULL,
+  ended_at              TIMESTAMPTZ,
+  duration_ms           INTEGER,
+  status                TEXT CHECK (status IN ('pass', 'fail')),
+  total_tests           INTEGER,
+  passed_tests          INTEGER,
+  failed_tests          INTEGER,
+  errors_between_tests  INTEGER,
+  git_sha               TEXT,
+  git_dirty             BOOLEAN,
+  runtime_version       TEXT,
+  test_args             TEXT
+);
+
+CREATE TABLE IF NOT EXISTS flaky_test_failures (
+  id             BIGSERIAL PRIMARY KEY,
+  run_id         TEXT NOT NULL REFERENCES flaky_test_runs(run_id),
+  test_file      TEXT NOT NULL,
+  test_name      TEXT NOT NULL,
+  failure_kind   TEXT NOT NULL CHECK (failure_kind IN ('assertion', 'timeout', 'uncaught', 'unknown')),
+  error_message  TEXT,
+  error_stack    TEXT,
+  duration_ms    INTEGER,
+  failed_at      TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_flaky_failures_test ON flaky_test_failures(test_file, test_name);
+CREATE INDEX IF NOT EXISTS idx_flaky_failures_run  ON flaky_test_failures(run_id);
+CREATE INDEX IF NOT EXISTS idx_flaky_failures_at   ON flaky_test_failures(failed_at);

--- a/packages/store-postgres/tsconfig.json
+++ b/packages/store-postgres/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/store-sqlite/package.json
+++ b/packages/store-sqlite/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@flaky-tests/store-sqlite",
+  "version": "0.1.0",
+  "description": "SQLite store adapter for flaky-tests (Bun built-in)",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./report": "./src/report.ts"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@flaky-tests/core": "workspace:*"
+  },
+  "devDependencies": {
+    "bun-types": "latest"
+  },
+  "engines": {
+    "bun": ">=1.3.0"
+  }
+}

--- a/packages/store-sqlite/src/index.ts
+++ b/packages/store-sqlite/src/index.ts
@@ -1,0 +1,183 @@
+import { mkdirSync } from 'node:fs'
+import { Database } from 'bun:sqlite'
+import type {
+  InsertFailureInput,
+  InsertRunInput,
+  IStore,
+  UpdateRunInput,
+} from '@flaky-tests/core'
+
+export interface SqliteStoreOptions {
+  /** Path to the SQLite database file. Defaults to node_modules/.cache/flaky-tests/failures.db */
+  dbPath?: string
+}
+
+const DEFAULT_DB_PATH = 'node_modules/.cache/flaky-tests/failures.db'
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS runs (
+  run_id                TEXT PRIMARY KEY,
+  started_at            TEXT NOT NULL,
+  ended_at              TEXT,
+  duration_ms           INTEGER,
+  status                TEXT,
+  total_tests           INTEGER,
+  passed_tests          INTEGER,
+  failed_tests          INTEGER,
+  errors_between_tests  INTEGER,
+  git_sha               TEXT,
+  git_dirty             INTEGER,
+  runtime_version       TEXT,
+  test_args             TEXT
+);
+
+CREATE TABLE IF NOT EXISTS failures (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id         TEXT NOT NULL REFERENCES runs(run_id),
+  test_file      TEXT NOT NULL,
+  test_name      TEXT NOT NULL,
+  failure_kind   TEXT NOT NULL,
+  error_message  TEXT,
+  error_stack    TEXT,
+  duration_ms    INTEGER,
+  failed_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_failures_test ON failures(test_file, test_name);
+CREATE INDEX IF NOT EXISTS idx_failures_run  ON failures(run_id);
+`
+
+function ensureDirectory(dbPath: string): void {
+  const lastSlash = dbPath.lastIndexOf('/')
+  if (lastSlash <= 0) return
+  const parent = dbPath.slice(0, lastSlash)
+  try {
+    mkdirSync(parent, { recursive: true })
+  } catch {
+    // Directory already exists or cannot be created; let Database attempt anyway.
+  }
+}
+
+export class SqliteStore implements IStore {
+  private db: Database
+
+  constructor(options: SqliteStoreOptions = {}) {
+    const dbPath = options.dbPath ?? DEFAULT_DB_PATH
+    ensureDirectory(dbPath)
+    this.db = new Database(dbPath, { create: true })
+    this.db.exec('PRAGMA journal_mode = WAL')
+    this.db.exec(SCHEMA)
+    this.migrate()
+  }
+
+  /**
+   * Idempotent column adds for databases created before schema updates.
+   * SQLite lacks `ADD COLUMN IF NOT EXISTS`, so each ALTER throws when the
+   * column already exists — we catch and ignore.
+   */
+  private migrate(): void {
+    const migrations = [
+      'ALTER TABLE runs ADD COLUMN passed_tests INTEGER',
+      'ALTER TABLE runs ADD COLUMN errors_between_tests INTEGER',
+      'ALTER TABLE runs ADD COLUMN runtime_version TEXT',
+      'ALTER TABLE runs ADD COLUMN test_args TEXT',
+    ]
+    for (const stmt of migrations) {
+      try {
+        this.db.exec(stmt)
+      } catch {
+        // Column already present.
+      }
+    }
+  }
+
+  async insertRun(input: InsertRunInput): Promise<void> {
+    this.db.run(
+      `INSERT INTO runs (run_id, started_at, git_sha, git_dirty, runtime_version, test_args)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        input.runId,
+        input.startedAt,
+        input.gitSha ?? null,
+        input.gitDirty != null ? (input.gitDirty ? 1 : 0) : null,
+        input.runtimeVersion ?? null,
+        input.testArgs ?? null,
+      ],
+    )
+  }
+
+  async updateRun(runId: string, input: UpdateRunInput): Promise<void> {
+    this.db.run(
+      `UPDATE runs
+          SET ended_at             = ?,
+              duration_ms          = ?,
+              status               = ?,
+              total_tests          = ?,
+              passed_tests         = ?,
+              failed_tests         = ?,
+              errors_between_tests = ?
+        WHERE run_id = ?`,
+      [
+        input.endedAt ?? null,
+        input.durationMs ?? null,
+        input.status ?? null,
+        input.totalTests ?? null,
+        input.passedTests ?? null,
+        input.failedTests ?? null,
+        input.errorsBetweenTests ?? null,
+        runId,
+      ],
+    )
+  }
+
+  async insertFailure(input: InsertFailureInput): Promise<void> {
+    this.db.run(
+      `INSERT INTO failures
+         (run_id, test_file, test_name, failure_kind, error_message, error_stack, duration_ms, failed_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        input.runId,
+        input.testFile,
+        input.testName,
+        input.failureKind,
+        input.errorMessage ?? null,
+        input.errorStack ?? null,
+        input.durationMs != null ? Math.round(input.durationMs) : null,
+        input.failedAt,
+      ],
+    )
+  }
+
+  /**
+   * Reconcile a run's status against the real process exit code.
+   * Called by `run-tracked` when `bun test` exits non-zero but the preload
+   * recorded status='pass' (e.g. module-load errors bypassed the preload).
+   */
+  reconcileRun(runId: string): void {
+    const row = this.db
+      .query('SELECT status FROM runs WHERE run_id = ?')
+      .get(runId) as { status: string | null } | null
+
+    if (row === null || row.status !== 'pass') return
+
+    this.db.run(
+      `UPDATE runs
+          SET status               = 'fail',
+              errors_between_tests = COALESCE(errors_between_tests, 0) + 1
+        WHERE run_id = ?`,
+      [runId],
+    )
+    console.warn(
+      `[flaky-tests] Run ${runId} exited with failure but preload recorded status=pass. Overriding to fail.`,
+    )
+  }
+
+  async close(): Promise<void> {
+    this.db.close()
+  }
+
+  /** Expose the raw Database for advanced use (e.g. report generation). */
+  getDb(): Database {
+    return this.db
+  }
+}

--- a/packages/store-sqlite/src/report.ts
+++ b/packages/store-sqlite/src/report.ts
@@ -1,0 +1,503 @@
+/**
+ * Generates a self-contained HTML report from the flaky-tests SQLite DB.
+ *
+ * Usage:
+ *   bun packages/store-sqlite/src/report.ts
+ *   FLAKY_TESTS_DB=<path> bun packages/store-sqlite/src/report.ts
+ *   bun packages/store-sqlite/src/report.ts --out <path>
+ *   bun packages/store-sqlite/src/report.ts --open
+ */
+
+// biome-ignore-all lint/suspicious/noConsole: CLI script
+
+import { Database } from 'bun:sqlite'
+
+const DB_PATH =
+  process.env.FLAKY_TESTS_DB ?? 'node_modules/.cache/flaky-tests/failures.db'
+const DEFAULT_OUT_PATH = 'test-report.html'
+const outFlagIndex = process.argv.indexOf('--out')
+const OUT_PATH =
+  outFlagIndex !== -1 && outFlagIndex + 1 < process.argv.length
+    ? (process.argv[outFlagIndex + 1] ?? DEFAULT_OUT_PATH)
+    : DEFAULT_OUT_PATH
+
+interface FlakyRow {
+  test_file: string
+  test_name: string
+  fails: number
+  last_failed: string
+  kinds: string
+}
+
+interface KindRow {
+  failure_kind: string
+  count: number
+}
+
+interface RunRow {
+  run_id: string
+  started_at: string
+  ended_at: string | null
+  duration_ms: number | null
+  status: string | null
+  total_tests: number | null
+  passed_tests: number | null
+  failed_tests: number | null
+  errors_between_tests: number | null
+  git_sha: string | null
+  git_dirty: number | null
+}
+
+interface HotFileRow {
+  test_file: string
+  fails: number
+  distinct_tests: number
+}
+
+interface Summary {
+  activeFlakyTests: number
+  dominantKind: { kind: string; count: number } | null
+  worstFile: { file: string; fails: number } | null
+  recentRunPassRate: number | null
+}
+
+function loadData(): {
+  summary: Summary
+  flaky: FlakyRow[]
+  kinds: KindRow[]
+  recentRuns: RunRow[]
+  hotFiles: HotFileRow[]
+  totalFailures: number
+  totalRuns: number
+} {
+  const db = new Database(DB_PATH, { readonly: true })
+
+  const flaky = db
+    .query(
+      `SELECT f.test_file, f.test_name,
+              COUNT(*) AS fails,
+              MAX(f.failed_at) AS last_failed,
+              GROUP_CONCAT(DISTINCT f.failure_kind) AS kinds
+         FROM failures f
+         JOIN runs r ON r.run_id = f.run_id
+        WHERE r.failed_tests < 10
+          AND r.ended_at IS NOT NULL
+          AND f.failed_at > datetime('now', '-30 days')
+        GROUP BY f.test_file, f.test_name
+        ORDER BY fails DESC
+        LIMIT 20`,
+    )
+    .all() as FlakyRow[]
+
+  const kinds = db
+    .query(
+      `SELECT failure_kind, COUNT(*) AS count
+         FROM failures
+        WHERE failed_at > datetime('now', '-30 days')
+        GROUP BY failure_kind
+        ORDER BY count DESC`,
+    )
+    .all() as KindRow[]
+
+  const recentRuns = db
+    .query(
+      `SELECT run_id, started_at, ended_at, duration_ms, status,
+              total_tests, passed_tests, failed_tests, errors_between_tests,
+              git_sha, git_dirty
+         FROM runs
+        ORDER BY started_at DESC
+        LIMIT 20`,
+    )
+    .all() as RunRow[]
+
+  const hotFiles = db
+    .query(
+      `SELECT test_file,
+              COUNT(*) AS fails,
+              COUNT(DISTINCT test_name) AS distinct_tests
+         FROM failures
+        WHERE failed_at > datetime('now', '-30 days')
+        GROUP BY test_file
+        ORDER BY fails DESC
+        LIMIT 15`,
+    )
+    .all() as HotFileRow[]
+
+  const totalFailures = (
+    db.query('SELECT COUNT(*) AS n FROM failures').get() as { n: number }
+  ).n
+  const totalRuns = (
+    db.query('SELECT COUNT(*) AS n FROM runs').get() as { n: number }
+  ).n
+
+  const activeFlakyTests = (
+    db
+      .query(
+        `SELECT COUNT(*) AS n FROM (
+           SELECT 1
+             FROM failures f
+             JOIN runs r ON r.run_id = f.run_id
+            WHERE r.failed_tests < 10
+              AND r.ended_at IS NOT NULL
+              AND f.failed_at > datetime('now', '-30 days')
+            GROUP BY f.test_file, f.test_name
+           HAVING COUNT(*) >= 2
+         )`,
+      )
+      .get() as { n: number }
+  ).n
+
+  const dominantKindRow = db
+    .query(
+      `SELECT failure_kind AS kind, COUNT(*) AS count
+         FROM failures
+        WHERE failed_at > datetime('now', '-30 days')
+        GROUP BY failure_kind
+        ORDER BY count DESC
+        LIMIT 1`,
+    )
+    .get() as { kind: string; count: number } | null
+
+  const worstFileRow = db
+    .query(
+      `SELECT test_file AS file, COUNT(*) AS fails
+         FROM failures
+        WHERE failed_at > datetime('now', '-30 days')
+        GROUP BY test_file
+        ORDER BY fails DESC
+        LIMIT 1`,
+    )
+    .get() as { file: string; fails: number } | null
+
+  const recentRunStats = db
+    .query(
+      `SELECT COUNT(*) AS total,
+              SUM(CASE WHEN status = 'pass' THEN 1 ELSE 0 END) AS passed
+         FROM runs
+        WHERE ended_at IS NOT NULL
+          AND started_at > datetime('now', '-30 days')`,
+    )
+    .get() as { total: number; passed: number }
+
+  const recentRunPassRate =
+    recentRunStats.total > 0
+      ? recentRunStats.passed / recentRunStats.total
+      : null
+
+  db.close()
+
+  return {
+    summary: { activeFlakyTests, dominantKind: dominantKindRow, worstFile: worstFileRow, recentRunPassRate },
+    flaky,
+    kinds,
+    recentRuns,
+    hotFiles,
+    totalFailures,
+    totalRuns,
+  }
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+function severityClass(count: number): string {
+  if (count >= 10) return 'sev-high'
+  if (count >= 5) return 'sev-med'
+  if (count >= 2) return 'sev-low'
+  return 'sev-single'
+}
+
+function kindBadge(kind: string): string {
+  const safe = escapeHtml(kind)
+  return `<span class="badge kind-${safe}">${safe}</span>`
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return '—'
+  if (ms < 1000) return `${ms}ms`
+  const s = ms / 1000
+  if (s < 60) return `${s.toFixed(1)}s`
+  return `${Math.floor(s / 60)}m ${Math.round(s % 60)}s`
+}
+
+function shortSha(sha: string | null): string {
+  if (sha === null) return '—'
+  return sha.slice(0, 7)
+}
+
+function formatRelative(iso: string): string {
+  const diffSec = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (diffSec < 60) return `${diffSec}s ago`
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
+  return `${Math.floor(diffSec / 86400)}d ago`
+}
+
+function passRateTone(pct: number | null): string {
+  if (pct === null) return 'tone-muted'
+  if (pct >= 95) return 'tone-good'
+  if (pct >= 80) return 'tone-warn'
+  return 'tone-bad'
+}
+
+function renderSummary(s: Summary): string {
+  const flakyTone = s.activeFlakyTests === 0 ? 'tone-good' : s.activeFlakyTests <= 3 ? 'tone-warn' : 'tone-bad'
+  const flakyLabel = s.activeFlakyTests === 0 ? 'none' : `${s.activeFlakyTests} test${s.activeFlakyTests === 1 ? '' : 's'}`
+  const kindLabel = s.dominantKind
+    ? `<span class="badge kind-${escapeHtml(s.dominantKind.kind)}">${escapeHtml(s.dominantKind.kind)}</span>`
+    : '<span class="muted">—</span>'
+  const fileLabel = s.worstFile ? escapeHtml(s.worstFile.file.split('/').pop() ?? s.worstFile.file) : '—'
+  const pct = s.recentRunPassRate !== null ? Math.round(s.recentRunPassRate * 100) : null
+
+  return `<section class="summary-grid">
+    <div class="summary-card ${flakyTone}">
+      <div class="summary-label">Active flaky tests</div>
+      <div class="summary-value">${flakyLabel}</div>
+      <div class="summary-hint">Distinct tests that failed &ge;2&times; in last 30 days</div>
+    </div>
+    <div class="summary-card ${passRateTone(pct)}">
+      <div class="summary-label">Recent run pass rate</div>
+      <div class="summary-value">${pct !== null ? `${pct}%` : '—'}</div>
+      <div class="summary-hint">Clean runs over last 30 days</div>
+    </div>
+    <div class="summary-card">
+      <div class="summary-label">Dominant failure kind</div>
+      <div class="summary-value">${kindLabel}</div>
+      <div class="summary-hint">${s.dominantKind ? escapeHtml(`${s.dominantKind.count} failures`) : 'no failures'}</div>
+    </div>
+    <div class="summary-card"${s.worstFile ? ` title="${escapeHtml(s.worstFile.file)}"` : ''}>
+      <div class="summary-label">Worst file</div>
+      <div class="summary-value mono summary-file">${fileLabel}</div>
+      <div class="summary-hint">${s.worstFile ? escapeHtml(`${s.worstFile.fails} failures`) : 'no failures'}</div>
+    </div>
+  </section>`
+}
+
+function renderFlaky(rows: FlakyRow[]): string {
+  if (rows.length === 0) return '<p class="empty">No failures in the last 30 days. Clean house.</p>'
+  const items = rows.map((r) => {
+    const kinds = r.kinds.split(',').map((k) => kindBadge(k.trim())).join(' ')
+    return `<tr>
+      <td><span class="count ${severityClass(r.fails)}">${r.fails}</span></td>
+      <td class="test-name">${escapeHtml(r.test_name)}</td>
+      <td class="file-path">${escapeHtml(r.test_file)}</td>
+      <td>${kinds}</td>
+      <td class="muted">${formatRelative(r.last_failed)}</td>
+    </tr>`
+  }).join('')
+  return `<table>
+    <thead><tr><th>Fails</th><th>Test</th><th>File</th><th>Kinds</th><th>Last seen</th></tr></thead>
+    <tbody>${items}</tbody>
+  </table>`
+}
+
+function renderKinds(rows: KindRow[]): string {
+  if (rows.length === 0) return '<p class="empty">No data.</p>'
+  const total = rows.reduce((s, r) => s + r.count, 0)
+  return `<div class="kind-grid">${rows.map((r) => {
+    const pct = total === 0 ? 0 : Math.round((r.count / total) * 100)
+    return `<div class="kind-card kind-${escapeHtml(r.failure_kind)}">
+      <div class="kind-label">${escapeHtml(r.failure_kind)}</div>
+      <div class="kind-count">${r.count}</div>
+      <div class="kind-pct">${pct}%</div>
+    </div>`
+  }).join('')}</div>`
+}
+
+function statusClass(status: string | null): string {
+  if (status === 'pass') return 'status-pass'
+  if (status === 'fail') return 'status-fail'
+  return 'status-crashed'
+}
+
+function renderRuns(rows: RunRow[]): string {
+  if (rows.length === 0) return '<p class="empty">No runs recorded.</p>'
+  const items = rows.map((r) => {
+    const dirty = r.git_dirty === 1 ? '<span class="dirty" title="working tree dirty">●</span>' : ''
+    const passed = r.passed_tests ?? 0
+    const failed = r.failed_tests ?? 0
+    const errs = r.errors_between_tests ?? 0
+    return `<tr>
+      <td><span class="status ${statusClass(r.status)}">${r.status ?? 'crashed'}</span></td>
+      <td class="muted">${formatRelative(r.started_at)}</td>
+      <td>${formatDuration(r.duration_ms)}</td>
+      <td>${r.total_tests ?? 0}</td>
+      <td>${passed > 0 ? `<span class="pass-count">${passed}</span>` : '0'}</td>
+      <td>${failed > 0 ? `<span class="fail-count">${failed}</span>` : '0'}</td>
+      <td>${errs > 0 ? `<span class="fail-count" title="errors outside tests">${errs}</span>` : '0'}</td>
+      <td class="muted mono">${shortSha(r.git_sha)}${dirty}</td>
+    </tr>`
+  }).join('')
+  return `<table>
+    <thead><tr><th>Status</th><th>When</th><th>Duration</th><th>Total</th><th>Passed</th><th>Failed</th><th>Errors</th><th>SHA</th></tr></thead>
+    <tbody>${items}</tbody>
+  </table>`
+}
+
+function renderHotFiles(rows: HotFileRow[]): string {
+  if (rows.length === 0) return '<p class="empty">No data.</p>'
+  const items = rows.map((r) => `<tr>
+    <td><span class="count ${severityClass(r.fails)}">${r.fails}</span></td>
+    <td>${r.distinct_tests}</td>
+    <td class="file-path">${escapeHtml(r.test_file)}</td>
+  </tr>`).join('')
+  return `<table>
+    <thead><tr><th>Fails</th><th>Distinct tests</th><th>File</th></tr></thead>
+    <tbody>${items}</tbody>
+  </table>`
+}
+
+const STYLES = `
+:root {
+  --bg: #0d1117; --surface: #161b22; --surface-2: #1f2630; --border: #30363d;
+  --text: #e6edf3; --text-muted: #8b949e; --accent: #58a6ff;
+  --pass: #3fb950; --fail: #f85149; --warn: #d29922; --crashed: #8b949e;
+  --kind-assertion: #58a6ff; --kind-timeout: #d29922;
+  --kind-uncaught: #f85149; --kind-unknown: #8b949e;
+  --sev-single: #3fb950; --sev-low: #d29922; --sev-med: #fb8500; --sev-high: #f85149;
+}
+* { box-sizing: border-box; }
+body { font: 14px/1.5 ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif; background: var(--bg); color: var(--text); margin: 0; padding: 2rem; max-width: 1200px; margin-inline: auto; }
+header { display: flex; align-items: center; justify-content: space-between; gap: 2rem; padding-bottom: 1rem; border-bottom: 1px solid var(--border); margin-bottom: 2rem; }
+h1 { margin: 0; font-size: 1.5rem; font-weight: 600; font-family: ui-monospace,"SF Mono",Menlo,Consolas,monospace; }
+h2 { margin: 2rem 0 1rem; font-size: 1.1rem; font-weight: 600; }
+.subtitle { color: var(--text-muted); font-size: 0.85rem; }
+section { margin-bottom: 2.5rem; }
+table { width: 100%; border-collapse: collapse; background: var(--surface); border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
+th, td { text-align: left; padding: 0.6rem 0.9rem; border-bottom: 1px solid var(--border); vertical-align: middle; }
+th { background: var(--surface-2); font-weight: 600; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); }
+tr:last-child td { border-bottom: none; }
+tr:hover td { background: var(--surface-2); }
+.muted { color: var(--text-muted); }
+.mono { font-family: ui-monospace,"SF Mono",Menlo,Consolas,monospace; }
+.file-path { font-family: ui-monospace,"SF Mono",Menlo,Consolas,monospace; font-size: 0.85rem; color: var(--text-muted); }
+.test-name { font-weight: 500; }
+.count { display: inline-block; min-width: 2.25rem; text-align: center; padding: 0.2rem 0.5rem; border-radius: 4px; font-weight: 600; font-family: ui-monospace,"SF Mono",Menlo,Consolas,monospace; font-size: 0.85rem; }
+.sev-single { background: color-mix(in srgb,var(--sev-single) 20%,transparent); color: var(--sev-single); }
+.sev-low    { background: color-mix(in srgb,var(--sev-low) 20%,transparent); color: var(--sev-low); }
+.sev-med    { background: color-mix(in srgb,var(--sev-med) 25%,transparent); color: var(--sev-med); }
+.sev-high   { background: color-mix(in srgb,var(--sev-high) 25%,transparent); color: var(--sev-high); }
+.badge { display: inline-block; padding: 0.1rem 0.45rem; border-radius: 999px; font-size: 0.75rem; font-weight: 500; border: 1px solid transparent; }
+.kind-assertion { background: color-mix(in srgb,var(--kind-assertion) 18%,transparent); color: var(--kind-assertion); border-color: color-mix(in srgb,var(--kind-assertion) 35%,transparent); }
+.kind-timeout   { background: color-mix(in srgb,var(--kind-timeout) 20%,transparent); color: var(--kind-timeout); border-color: color-mix(in srgb,var(--kind-timeout) 40%,transparent); }
+.kind-uncaught  { background: color-mix(in srgb,var(--kind-uncaught) 20%,transparent); color: var(--kind-uncaught); border-color: color-mix(in srgb,var(--kind-uncaught) 40%,transparent); }
+.kind-unknown   { background: color-mix(in srgb,var(--kind-unknown) 20%,transparent); color: var(--kind-unknown); border-color: color-mix(in srgb,var(--kind-unknown) 40%,transparent); }
+.kind-grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(160px,1fr)); gap: 1rem; }
+.kind-card { padding: 1rem; border-radius: 8px; border: 1px solid var(--border); background: var(--surface); }
+.kind-card.kind-assertion { border-left: 4px solid var(--kind-assertion); }
+.kind-card.kind-timeout   { border-left: 4px solid var(--kind-timeout); }
+.kind-card.kind-uncaught  { border-left: 4px solid var(--kind-uncaught); }
+.kind-card.kind-unknown   { border-left: 4px solid var(--kind-unknown); }
+.kind-label { text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.08em; color: var(--text-muted); font-weight: 600; }
+.kind-count { font-size: 2rem; font-weight: 700; margin-top: 0.25rem; }
+.kind-pct { color: var(--text-muted); font-size: 0.8rem; }
+.status { display: inline-block; padding: 0.15rem 0.55rem; border-radius: 4px; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+.status-pass    { background: color-mix(in srgb,var(--pass) 20%,transparent); color: var(--pass); }
+.status-fail    { background: color-mix(in srgb,var(--fail) 20%,transparent); color: var(--fail); }
+.status-crashed { background: color-mix(in srgb,var(--crashed) 25%,transparent); color: var(--crashed); }
+.fail-count { color: var(--fail); font-weight: 600; }
+.pass-count { color: var(--pass); font-weight: 600; }
+.dirty { color: var(--warn); margin-left: 0.3rem; font-size: 0.7rem; }
+.summary-grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(200px,1fr)); gap: 1rem; margin-bottom: 2.5rem; }
+.summary-card { padding: 1rem 1.25rem; border-radius: 8px; border: 1px solid var(--border); background: var(--surface); border-left: 4px solid var(--text-muted); }
+.summary-card.tone-good { border-left-color: var(--pass); }
+.summary-card.tone-warn { border-left-color: var(--warn); }
+.summary-card.tone-bad  { border-left-color: var(--fail); }
+.summary-card.tone-muted { border-left-color: var(--text-muted); }
+.summary-label { text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.08em; color: var(--text-muted); font-weight: 600; }
+.summary-value { font-size: 1.75rem; font-weight: 700; margin-top: 0.25rem; line-height: 1.2; }
+.summary-file { font-size: 1rem; word-break: break-all; }
+.summary-hint { color: var(--text-muted); font-size: 0.8rem; margin-top: 0.35rem; }
+footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--border); text-align: center; color: var(--text-muted); font-size: 0.8rem; }
+footer a { color: var(--text-muted); text-decoration: none; border-bottom: 1px dotted var(--border); }
+footer a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+.sep { color: var(--border); margin: 0 0.6rem; }
+.empty { padding: 2rem; text-align: center; color: var(--text-muted); background: var(--surface); border: 1px dashed var(--border); border-radius: 6px; }
+`
+
+function render(data: ReturnType<typeof loadData>): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>flaky-tests report</title>
+<style>${STYLES}</style>
+</head>
+<body>
+  <header>
+    <div>
+      <h1>flaky-tests</h1>
+      <div class="subtitle">Generated ${escapeHtml(new Date().toISOString())} &middot; ${escapeHtml(DB_PATH)}</div>
+    </div>
+    <div style="display:flex;gap:2rem;color:var(--text-muted);font-size:0.9rem">
+      <div><strong style="color:var(--text)">${data.totalRuns}</strong> runs</div>
+      <div><strong style="color:var(--text)">${data.totalFailures}</strong> recorded failures</div>
+    </div>
+  </header>
+
+  ${renderSummary(data.summary)}
+
+  <section>
+    <h2>Top 20 flaky tests (last 30 days)</h2>
+    <p class="subtitle">Runs with &ge;10 simultaneous failures and crashed runs excluded.</p>
+    ${renderFlaky(data.flaky)}
+  </section>
+
+  <section>
+    <h2>Failure kinds (last 30 days)</h2>
+    ${renderKinds(data.kinds)}
+  </section>
+
+  <section>
+    <h2>Hot spots by file (last 30 days)</h2>
+    ${renderHotFiles(data.hotFiles)}
+  </section>
+
+  <section>
+    <h2>Recent runs</h2>
+    ${renderRuns(data.recentRuns)}
+  </section>
+
+  <footer>
+    Generated by <a href="https://github.com/brewpirate/flaky-tests">flaky-tests</a>
+  </footer>
+</body>
+</html>`
+}
+
+function openInBrowser(filePath: string): void {
+  const abs = Bun.fileURLToPath(new URL(filePath, `file://${process.cwd()}/`))
+  const url = `file://${abs}`
+  const envBrowser = process.env.BROWSER
+  let cmd: string[]
+  if (envBrowser) cmd = [envBrowser, url]
+  else if (process.platform === 'darwin') cmd = ['open', url]
+  else if (process.platform === 'win32') cmd = ['cmd', '/c', 'start', '', url]
+  else cmd = ['xdg-open', url]
+  try {
+    Bun.spawn({ cmd, stdout: 'ignore', stderr: 'ignore' }).unref?.()
+  } catch (e) {
+    console.warn(`[flaky-tests] Could not open browser:`, e)
+  }
+}
+
+async function main(): Promise<void> {
+  if (!(await Bun.file(DB_PATH).exists())) {
+    console.error(`[flaky-tests] DB not found at ${DB_PATH}. Run tests at least once.`)
+    process.exit(1)
+  }
+  const data = loadData()
+  const html = render(data)
+  await Bun.write(OUT_PATH, html)
+  console.log(`[flaky-tests] Wrote ${OUT_PATH} (${data.totalRuns} runs, ${data.totalFailures} failures)`)
+  if (process.argv.includes('--open')) openInBrowser(OUT_PATH)
+}
+
+await main()

--- a/packages/store-sqlite/src/schema.sql
+++ b/packages/store-sqlite/src/schema.sql
@@ -1,0 +1,44 @@
+-- flaky-tests SQLite schema.
+--
+-- Flakiness reference query:
+--
+--   SELECT f.test_file, f.test_name, COUNT(*) AS fails, MAX(f.failed_at) AS last
+--   FROM failures f
+--   JOIN runs r ON r.run_id = f.run_id
+--   WHERE r.failed_tests < 10              -- skip suite-wide breakage runs
+--     AND r.ended_at IS NOT NULL           -- skip crashed runs
+--     AND f.failed_at > datetime('now', '-30 days')
+--   GROUP BY f.test_file, f.test_name
+--   ORDER BY fails DESC
+--   LIMIT 20;
+
+CREATE TABLE IF NOT EXISTS runs (
+  run_id                TEXT PRIMARY KEY,
+  started_at            TEXT NOT NULL,
+  ended_at              TEXT,
+  duration_ms           INTEGER,
+  status                TEXT,
+  total_tests           INTEGER,
+  passed_tests          INTEGER,
+  failed_tests          INTEGER,
+  errors_between_tests  INTEGER,
+  git_sha               TEXT,
+  git_dirty             INTEGER,
+  runtime_version       TEXT,
+  test_args             TEXT
+);
+
+CREATE TABLE IF NOT EXISTS failures (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id         TEXT NOT NULL REFERENCES runs(run_id),
+  test_file      TEXT NOT NULL,
+  test_name      TEXT NOT NULL,
+  failure_kind   TEXT NOT NULL,
+  error_message  TEXT,
+  error_stack    TEXT,
+  duration_ms    INTEGER,
+  failed_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_failures_test ON failures(test_file, test_name);
+CREATE INDEX IF NOT EXISTS idx_failures_run  ON failures(run_id);

--- a/packages/store-sqlite/tsconfig.json
+++ b/packages/store-sqlite/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/store-supabase/package.json
+++ b/packages/store-supabase/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@flaky-tests/store-supabase",
+  "version": "0.1.0",
+  "description": "Supabase store adapter for flaky-tests",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@flaky-tests/core": "workspace:*",
+    "@supabase/supabase-js": "^2.0.0"
+  }
+}

--- a/packages/store-supabase/src/index.ts
+++ b/packages/store-supabase/src/index.ts
@@ -1,0 +1,79 @@
+import { createClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type {
+  InsertFailureInput,
+  InsertRunInput,
+  IStore,
+  UpdateRunInput,
+} from '@flaky-tests/core'
+
+export interface SupabaseStoreOptions {
+  /** Supabase project URL */
+  url: string
+  /** Supabase anon or service role key */
+  key: string
+  /**
+   * Table name prefix. Defaults to `flaky_test`, producing tables
+   * `flaky_test_runs` and `flaky_test_failures`.
+   */
+  tablePrefix?: string
+}
+
+export class SupabaseStore implements IStore {
+  private client: SupabaseClient
+  private runsTable: string
+  private failuresTable: string
+
+  constructor(options: SupabaseStoreOptions) {
+    this.client = createClient(options.url, options.key)
+    const prefix = options.tablePrefix ?? 'flaky_test'
+    this.runsTable = `${prefix}_runs`
+    this.failuresTable = `${prefix}_failures`
+  }
+
+  async insertRun(input: InsertRunInput): Promise<void> {
+    const { error } = await this.client.from(this.runsTable).insert({
+      run_id: input.runId,
+      started_at: input.startedAt,
+      git_sha: input.gitSha ?? null,
+      git_dirty: input.gitDirty ?? null,
+      runtime_version: input.runtimeVersion ?? null,
+      test_args: input.testArgs ?? null,
+    })
+    if (error) throw new Error(`[flaky-tests/store-supabase] insertRun: ${error.message}`)
+  }
+
+  async updateRun(runId: string, input: UpdateRunInput): Promise<void> {
+    const { error } = await this.client
+      .from(this.runsTable)
+      .update({
+        ended_at: input.endedAt ?? null,
+        duration_ms: input.durationMs ?? null,
+        status: input.status ?? null,
+        total_tests: input.totalTests ?? null,
+        passed_tests: input.passedTests ?? null,
+        failed_tests: input.failedTests ?? null,
+        errors_between_tests: input.errorsBetweenTests ?? null,
+      })
+      .eq('run_id', runId)
+    if (error) throw new Error(`[flaky-tests/store-supabase] updateRun: ${error.message}`)
+  }
+
+  async insertFailure(input: InsertFailureInput): Promise<void> {
+    const { error } = await this.client.from(this.failuresTable).insert({
+      run_id: input.runId,
+      test_file: input.testFile,
+      test_name: input.testName,
+      failure_kind: input.failureKind,
+      error_message: input.errorMessage ?? null,
+      error_stack: input.errorStack ?? null,
+      duration_ms: input.durationMs != null ? Math.round(input.durationMs) : null,
+      failed_at: input.failedAt,
+    })
+    if (error) throw new Error(`[flaky-tests/store-supabase] insertFailure: ${error.message}`)
+  }
+
+  async close(): Promise<void> {
+    // Supabase JS client has no explicit close; connections are managed internally.
+  }
+}

--- a/packages/store-supabase/src/schema.sql
+++ b/packages/store-supabase/src/schema.sql
@@ -1,0 +1,45 @@
+-- Run this in your Supabase SQL editor to create the required tables.
+
+CREATE TABLE IF NOT EXISTS flaky_test_runs (
+  run_id                TEXT PRIMARY KEY,
+  started_at            TIMESTAMPTZ NOT NULL,
+  ended_at              TIMESTAMPTZ,
+  duration_ms           INTEGER,
+  status                TEXT CHECK (status IN ('pass', 'fail')),
+  total_tests           INTEGER,
+  passed_tests          INTEGER,
+  failed_tests          INTEGER,
+  errors_between_tests  INTEGER,
+  git_sha               TEXT,
+  git_dirty             BOOLEAN,
+  runtime_version       TEXT,
+  test_args             TEXT
+);
+
+CREATE TABLE IF NOT EXISTS flaky_test_failures (
+  id             BIGSERIAL PRIMARY KEY,
+  run_id         TEXT NOT NULL REFERENCES flaky_test_runs(run_id),
+  test_file      TEXT NOT NULL,
+  test_name      TEXT NOT NULL,
+  failure_kind   TEXT NOT NULL CHECK (failure_kind IN ('assertion', 'timeout', 'uncaught', 'unknown')),
+  error_message  TEXT,
+  error_stack    TEXT,
+  duration_ms    INTEGER,
+  failed_at      TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_flaky_failures_test ON flaky_test_failures(test_file, test_name);
+CREATE INDEX IF NOT EXISTS idx_flaky_failures_run  ON flaky_test_failures(run_id);
+CREATE INDEX IF NOT EXISTS idx_flaky_failures_at   ON flaky_test_failures(failed_at);
+
+-- Flakiness reference query:
+--
+-- SELECT f.test_file, f.test_name, COUNT(*) AS fails, MAX(f.failed_at) AS last
+-- FROM flaky_test_failures f
+-- JOIN flaky_test_runs r ON r.run_id = f.run_id
+-- WHERE r.failed_tests < 10
+--   AND r.ended_at IS NOT NULL
+--   AND f.failed_at > NOW() - INTERVAL '30 days'
+-- GROUP BY f.test_file, f.test_name
+-- ORDER BY fails DESC
+-- LIMIT 20;

--- a/packages/store-supabase/tsconfig.json
+++ b/packages/store-supabase/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
## Summary

Ports `bun-flaky-tests` into a Bun workspace monorepo with a storage-agnostic core and separate packages for each runtime/backend.

## Packages

| Package | Description |
|---|---|
| `@flaky-tests/core` | `IStore` interface, shared types, `categorizeError`, `DescribeStack` |
| `@flaky-tests/store-sqlite` | Bun-native `bun:sqlite` adapter + HTML report CLI |
| `@flaky-tests/store-supabase` | `@supabase/supabase-js` adapter + `schema.sql` |
| `@flaky-tests/store-postgres` | `postgres` tagged-template adapter + `schema.sql` |
| `@flaky-tests/plugin-bun` | Bun preload (`createPreload` factory + default SQLite entry + `run-tracked` CLI) |
| `@flaky-tests/plugin-vitest` | `FlakyTestsReporter` (Vitest v1/v2/v3 compatible) |

## Usage

**Bun + SQLite (default):**
```toml
# bunfig.toml
[test]
preload = ["@flaky-tests/plugin-bun/preload"]
```

**Bun + custom store:**
```ts
// my-preload.ts
import { createPreload } from '@flaky-tests/plugin-bun'
import { SupabaseStore } from '@flaky-tests/store-supabase'

createPreload(new SupabaseStore({ url: '...', key: '...' }))
```

**Vitest:**
```ts
// vitest.config.ts
import { FlakyTestsReporter } from '@flaky-tests/plugin-vitest'
import { PostgresStore } from '@flaky-tests/store-postgres'

export default defineConfig({
  test: {
    reporters: ['default', new FlakyTestsReporter(new PostgresStore({ connectionString: '...' }))],
  },
})
```

## Notes
- Env vars renamed `TEST_TELEMETRY_*` → `FLAKY_TESTS_*`
- All `IStore` methods are `async` — SQLite wraps its sync calls transparently
- `run-tracked` reconciliation is currently SQLite-only (known gap)

https://claude.ai/code/session_01UqncEwG8gGNb6LKLSvMfvm