### PR TITLE
feat: GitHub issue generation

### DIFF
--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -22,6 +22,7 @@
 import { SqliteStore } from '@flaky-tests/store-sqlite'
 import type { FlakyPattern } from '@flaky-tests/core'
 import { copyToClipboard, generatePrompt } from './prompt'
+import { createIssue, findExistingIssue, resolveRepo } from './github'
 
 // --- Argument parsing (no deps, just process.argv) -----------------------
 
@@ -40,6 +41,7 @@ const windowDays = Number(option('window', 'FLAKY_TESTS_WINDOW') ?? 7)
 const threshold = Number(option('threshold', 'FLAKY_TESTS_THRESHOLD') ?? 2)
 const showPrompts = flag('prompt') || flag('copy')
 const doCopy = flag('copy')
+const doCreateIssue = flag('create-issue')
 
 // --- Main ----------------------------------------------------------------
 
@@ -83,8 +85,9 @@ async function main(): Promise<void> {
     }
     console.log()
   } else {
-    console.log(`  Run with --prompt to print investigation prompts`)
-    console.log(`  Run with --copy   to copy the first prompt to clipboard`)
+    console.log(`  Run with --prompt        to print investigation prompts`)
+    console.log(`  Run with --copy          to copy the first prompt to clipboard`)
+    console.log(`  Run with --create-issue  to open a GitHub issue for each pattern`)
     console.log()
   }
 
@@ -98,7 +101,43 @@ async function main(): Promise<void> {
     }
   }
 
+  if (doCreateIssue) {
+    await openGitHubIssues(patterns, windowDays)
+  }
+
   process.exit(1)
+}
+
+async function openGitHubIssues(patterns: FlakyPattern[], windowDays: number): Promise<void> {
+  const token = process.env.GITHUB_TOKEN
+  if (!token) {
+    console.log('⚠ --create-issue requires GITHUB_TOKEN to be set\n')
+    return
+  }
+
+  const repoInfo = resolveRepo()
+  if (!repoInfo) {
+    console.log('⚠ --create-issue: could not determine owner/repo. Set GITHUB_REPOSITORY or pass --repo owner/repo\n')
+    return
+  }
+
+  const config = { token, ...repoInfo }
+  console.log(`Opening issues in ${repoInfo.owner}/${repoInfo.repo}...\n`)
+
+  for (const pattern of patterns) {
+    try {
+      const existing = await findExistingIssue(config, pattern.testName)
+      if (existing !== null) {
+        console.log(`  ↩ #${existing} already open for: ${pattern.testName}`)
+        continue
+      }
+      const url = await createIssue(config, pattern, windowDays)
+      console.log(`  ✓ Opened: ${url}`)
+    } catch (error) {
+      console.log(`  ✗ Failed for "${pattern.testName}": ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+  console.log()
 }
 
 await main()

--- a/packages/cli/src/github.ts
+++ b/packages/cli/src/github.ts
@@ -1,0 +1,140 @@
+/**
+ * GitHub REST API helpers for issue creation.
+ * Uses native fetch — no external dependencies.
+ */
+
+// biome-ignore-all lint/suspicious/noConsole: CLI tool
+
+import type { FlakyPattern } from '@flaky-tests/core'
+import { generatePrompt } from './prompt'
+
+export interface GitHubConfig {
+  token: string
+  owner: string
+  repo: string
+}
+
+/**
+ * Resolve owner/repo from:
+ *   1. GITHUB_REPOSITORY env var (set automatically in Actions)
+ *   2. --repo <owner/repo> CLI flag
+ *   3. git remote origin URL (fallback for local runs)
+ */
+export function resolveRepo(): { owner: string; repo: string } | null {
+  // GitHub Actions sets this automatically
+  const envRepo = process.env.GITHUB_REPOSITORY
+  if (envRepo) {
+    const [owner, repo] = envRepo.split('/')
+    if (owner && repo) return { owner, repo }
+  }
+
+  // --repo flag
+  const idx = process.argv.indexOf('--repo')
+  if (idx !== -1 && idx + 1 < process.argv.length) {
+    const val = process.argv[idx + 1]!
+    const [owner, repo] = val.split('/')
+    if (owner && repo) return { owner, repo }
+  }
+
+  // Parse git remote
+  try {
+    const result = Bun.spawnSync({
+      cmd: ['git', 'remote', 'get-url', 'origin'],
+      stdout: 'pipe',
+      stderr: 'ignore',
+    })
+    if (result.exitCode === 0) {
+      const url = new TextDecoder().decode(result.stdout).trim()
+      // https://github.com/owner/repo.git  or  git@github.com:owner/repo.git
+      const match = url.match(/github\.com[/:]([^/]+)\/([^/.]+)/)
+      if (match) return { owner: match[1]!, repo: match[2]! }
+    }
+  } catch {
+    // git not available
+  }
+
+  return null
+}
+
+function githubHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+    'User-Agent': 'flaky-tests-cli',
+  }
+}
+
+/** Returns the issue number if an open issue for this test already exists. */
+export async function findExistingIssue(
+  config: GitHubConfig,
+  testName: string,
+): Promise<number | null> {
+  const title = issueTitle(testName)
+  const q = encodeURIComponent(
+    `repo:${config.owner}/${config.repo} is:issue is:open "${title}" in:title`,
+  )
+  const res = await fetch(`https://api.github.com/search/issues?q=${q}&per_page=1`, {
+    headers: githubHeaders(config.token),
+  })
+  if (!res.ok) return null
+  const data = (await res.json()) as { items: Array<{ number: number }> }
+  return data.items[0]?.number ?? null
+}
+
+/** Create a GitHub issue for a flaky pattern. Returns the issue URL. */
+export async function createIssue(
+  config: GitHubConfig,
+  pattern: FlakyPattern,
+  windowDays: number,
+): Promise<string> {
+  const res = await fetch(
+    `https://api.github.com/repos/${config.owner}/${config.repo}/issues`,
+    {
+      method: 'POST',
+      headers: githubHeaders(config.token),
+      body: JSON.stringify({
+        title: issueTitle(pattern.testName),
+        body: issueBody(pattern, windowDays),
+        labels: ['flaky-test'],
+      }),
+    },
+  )
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`GitHub API error ${res.status}: ${text}`)
+  }
+
+  const data = (await res.json()) as { html_url: string }
+  return data.html_url
+}
+
+function issueTitle(testName: string): string {
+  return `[flaky-test] ${testName}`
+}
+
+function issueBody(pattern: FlakyPattern, windowDays: number): string {
+  const prompt = generatePrompt(pattern, windowDays)
+
+  return `## Flaky test detected
+
+**Test:** \`${pattern.testName}\`
+**File:** \`${pattern.testFile}\`
+**Failures (last ${windowDays} days):** ${pattern.recentFails}
+**Kind:** ${pattern.failureKinds.join(', ')}
+${pattern.lastErrorMessage ? `**Last error:** ${pattern.lastErrorMessage.split('\n')[0]}` : ''}
+
+<details>
+<summary>Investigation prompt — copy to AI assistant</summary>
+
+\`\`\`
+${prompt}
+\`\`\`
+
+</details>
+
+---
+*Detected by [flaky-tests](https://github.com/brewpirate/flaky-tests)*`
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,3 @@
 export { generatePrompt, copyToClipboard } from './prompt'
+export { createIssue, findExistingIssue, resolveRepo } from './github'
+export type { GitHubConfig } from './github'


### PR DESCRIPTION
## Overview

When `flaky-tests check` detects a new pattern, automatically open a GitHub issue with the full context and generated investigation prompt attached.

## What ships in this PR

- `--create-issue` flag on the `check` CLI command
- GitHub issue template: test name, file, failure count, failure kind, error message, generated prompt in a collapsible section
- Deduplication: checks for an existing open issue with the same test name before creating a new one — no spam
- Uses `GITHUB_TOKEN` from environment (works in CI automatically)

## Issue shape

```markdown
## Flaky test detected: `auth > login > should redirect on success`

**File:** `tests/auth.test.ts`
**Failures (last 7 days):** 8
**Kind:** timeout
**Last error:** Expected redirect within 2000ms

<details>
<summary>Investigation prompt</summary>

[generated prompt]

</details>
```

## Depends on
- #1 (core lib)
- #2 (pattern detection)

https://claude.ai/code/session_01UqncEwG8gGNb6LKLSvMfvm