### PR TITLE
feat(ts): enable noUncheckedIndexedAccess + exactOptionalPropertyTypes

### DIFF
--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -56,7 +56,10 @@ async function resolveStore(): Promise<IStore> {
           'FLAKY_TESTS_CONNECTION_STRING is required for store=turso',
         )
       const { TursoStore } = await import('@flaky-tests/store-turso')
-      return new TursoStore({ url: connStr, authToken })
+      return new TursoStore({
+        url: connStr,
+        ...(authToken !== undefined && { authToken }),
+      })
     }
     case 'supabase': {
       if (!connStr || !authToken)
@@ -68,7 +71,9 @@ async function resolveStore(): Promise<IStore> {
     }
     case 'postgres': {
       const { PostgresStore } = await import('@flaky-tests/store-postgres')
-      return new PostgresStore({ connectionString: connStr })
+      return new PostgresStore(
+        connStr !== undefined ? { connectionString: connStr } : {},
+      )
     }
     default: {
       const { SqliteStore } = await import('@flaky-tests/store-sqlite')

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -59,10 +59,16 @@ export class PostgresStore implements IStore {
       this.sql = postgres({
         host: validated.host ?? 'localhost',
         port: validated.port ?? 5432,
-        database: validated.database,
-        username: validated.username,
-        password: validated.password,
-        ssl: validated.ssl,
+        ...(validated.database !== undefined && {
+          database: validated.database,
+        }),
+        ...(validated.username !== undefined && {
+          username: validated.username,
+        }),
+        ...(validated.password !== undefined && {
+          password: validated.password,
+        }),
+        ...(validated.ssl !== undefined && { ssl: validated.ssl }),
       })
     }
   }

--- a/packages/store-turso/src/index.ts
+++ b/packages/store-turso/src/index.ts
@@ -78,7 +78,9 @@ export class TursoStore implements IStore {
     const validated = parse(tursoStoreOptionsSchema, options)
     this.client = createClient({
       url: validated.url,
-      authToken: validated.authToken,
+      ...(validated.authToken !== undefined && {
+        authToken: validated.authToken,
+      }),
     })
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary

- Enables `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` at the root `tsconfig.json`. All 7 packages that `extends` it inherit the flags — no per-package edits needed.
- Fixes 4 real call sites that surfaced under `exactOptionalPropertyTypes`: `TursoStore`, `PostgresStore`, and two CLI store-resolver branches were passing `{ key: undefined }` into 3rd-party option slots.

## Why this matters

`postgres()` and `@libsql/client` both treat **"key absent"** differently from **"key present but undefined"** — env-variable fallbacks only engage when the key is absent. The old code silently disabled those fallbacks. The conditional-spread pattern (`...(x !== undefined && { x })`) restores intended behavior.

`noUncheckedIndexedAccess` produced **zero** fallout — existing array/record access was already defensive (`?.[0]`, `?? fallback`).

## Scope

Item 1 of `.local/plans/slop-pass-cherry-pick.md`. Follow-ups (separate PRs):
- Item 2: workspace typecheck in CI (will surface pre-existing test-file type errors that `build:types` skips)
- Items 3–6: runtime hardening (github.ts timeouts, preload idempotency, DescribeStack guards, categorizeError defenses)

## Test plan

- [x] `bun run build` green
- [x] `bun test` — 209 pass, 0 fail
- [x] `bun run check` (biome) — clean
- [x] `bun run build:types` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)