### PR TITLE
docs(rules): align .claude/rules with actual arktype usage

### DIFF
--- a/.claude/rules/naming-and-style.md
+++ b/.claude/rules/naming-and-style.md
@@ -11,7 +11,7 @@
 | Constants | SCREAMING_SNAKE | `MAX_RETRY_COUNT` |
 | Interfaces | PascalCase (no I prefix) | `Issue`, not `IIssue` |
 | Types | PascalCase | `IterationResult` |
-| Zod schemas | PascalCase + Schema | `IssueSchema` |
+| arktype schemas | lowerCamelCase + Schema | `flakyPatternSchema` |
 
 ## Verbose Names — No Abbreviations
 
@@ -149,7 +149,7 @@ if (array.length > 0) { ... }
 
 ## No Magic Numbers
 
-Use config values from Zod-validated `ConfigSchema`. Never scatter numeric literals.
+Use config values from an arktype-validated schema. Never scatter numeric literals.
 
 ```typescript
 // WRONG

--- a/.claude/rules/typescript-patterns.md
+++ b/.claude/rules/typescript-patterns.md
@@ -4,7 +4,7 @@
 
 ### No `any` Type
 
-Use `unknown` with Zod validation or type guards.
+Use `unknown` with arktype validation or type guards.
 
 ```typescript
 // WRONG
@@ -13,14 +13,14 @@ function processData(data: any) { return data.value }
 // WRONG — unsafe cast
 function processData(data: unknown) { return (data as Issue).title }
 
-// CORRECT — Zod validation
+// CORRECT — arktype validation via shared `parse` helper
 function processData(data: unknown): Issue {
-  return IssueSchema.parse(data)
+  return parse(issueSchema, data)
 }
 
 // CORRECT — type guard
 function isIssue(data: unknown): data is Issue {
-  return IssueSchema.safeParse(data).success
+  return !(issueSchema(data) instanceof type.errors)
 }
 ```
 
@@ -85,9 +85,9 @@ const limit = options.limit ?? 20
 
 **Exception**: `|| 0` is correct when guarding against `NaN` (e.g., `parseInt(value) || 0`), since `NaN ?? 0` does not catch `NaN`.
 
-### Discriminated Unions via Zod
+### Discriminated Unions via arktype
 
-Prefer `z.discriminatedUnion()` over hand-written type unions. See `zod-schemas.md`.
+Prefer an arktype union schema (`type("'a' | 'b' | 'c'")` for string literals, or an object union with a discriminator key) over hand-written TypeScript type unions when the shape also needs runtime validation. See `packages/core/src/schemas.ts` for examples like `failureKindSchema` and `runStatusSchema`.
 
 ## Patterns to Adopt
 
@@ -112,9 +112,7 @@ function isContextOverflow(error: unknown): error is ContextOverflowError {
 
 ### Exhaustive Switch with `never`
 
-**REQUIRED for `IssueState`** — all switch statements on `IssueState` must include a `never` exhaustiveness check. See `zod-schemas.md` for the full pattern.
-
-Recommended for other enums:
+Recommended for all enum-like discriminated unions:
 
 ```typescript
 function handleOutcome(outcome: IterationOutcome): void {


### PR DESCRIPTION
Three rule files still referenced Zod and a nonexistent `IssueSchema` / `zod-schemas.md` (template residue). Codebase is already on arktype.

- `typescript-patterns.md`: swap Zod example for arktype `parse()` + `type.errors` guard; replace the "Discriminated Unions via Zod" section; drop dead `IssueState` / `zod-schemas.md` refs
- `naming-and-style.md`: schema convention row now reads `arktype schemas | lowerCamelCase + Schema | flakyPatternSchema` (matches `gitHubConfigSchema`, `flakyPatternSchema`, etc.)

No code changes. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)