### PR TITLE
ci: add workspace typecheck gate

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Lint
         run: bun run check
 
+      # Emit .d.ts into each package's dist/ so tsc can resolve workspace
+      # imports — `exports["."]["types"]` points at ./dist/*.d.ts.
+      - name: Build types
+        run: bun run build:types
+
       - name: Typecheck
         run: bun run typecheck
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Lint
         run: bun run check
 
+      - name: Typecheck
+        run: bun run typecheck
+
       - name: Build
         run: bun run build
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,9 @@
       "dependencies": {
         "arktype": "^2.2.0",
       },
+      "devDependencies": {
+        "bun-types": "latest",
+      },
     },
     "packages/docs": {
       "name": "@flaky-tests/docs",
@@ -66,6 +69,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
+        "bun-types": "latest",
       },
       "peerDependencies": {
         "vitest": ">=1.0.0",
@@ -78,6 +82,9 @@
         "@flaky-tests/core": "workspace:*",
         "arktype": "^2.1.0",
         "postgres": "^3.4.0",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
       },
     },
     "packages/store-sqlite": {
@@ -99,6 +106,9 @@
         "@supabase/supabase-js": "^2.0.0",
         "arktype": "^2.1.0",
       },
+      "devDependencies": {
+        "bun-types": "latest",
+      },
     },
     "packages/store-turso": {
       "name": "@flaky-tests/store-turso",
@@ -107,6 +117,9 @@
         "@flaky-tests/core": "workspace:*",
         "@libsql/client": "^0.14.0",
         "arktype": "^2.1.0",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
       },
     },
   },
@@ -1294,6 +1307,16 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@expressive-code/plugin-shiki/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
+
+    "@flaky-tests/core/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "@flaky-tests/plugin-vitest/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "@flaky-tests/store-postgres/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "@flaky-tests/store-supabase/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "@flaky-tests/store-turso/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:all": "INTEGRATION=1 bun test",
     "test:report": "bun packages/store-sqlite/src/report.ts --open",
     "test:cli": "bun packages/cli/src/check.ts",
+    "typecheck": "for config in packages/cli/tsconfig.json packages/core/tsconfig.json packages/plugin-bun/tsconfig.json packages/plugin-vitest/tsconfig.json packages/store-postgres/tsconfig.json packages/store-sqlite/tsconfig.json packages/store-supabase/tsconfig.json packages/store-turso/tsconfig.json; do echo \"==> $config\"; tsc -p \"$config\" --noEmit || exit 1; done",
     "build": "bun run --filter '!@flaky-tests/docs' build",
     "build:types": "bun run --filter '!@flaky-tests/docs' build:types",
     "build:docs": "bun run --filter '@flaky-tests/docs' build",

--- a/packages/cli/src/github-api.test.ts
+++ b/packages/cli/src/github-api.test.ts
@@ -8,6 +8,13 @@ import {
   gitHubConfigSchema,
 } from './github'
 
+// Bun's `mock()` returns a Mock<> that lacks the `preconnect` method on
+// `typeof fetch`. Cast through unknown so each test can supply only the
+// call signature it actually needs.
+const mockFetch = (
+  implementation: (...args: never[]) => Promise<Response>,
+): typeof fetch => mock(implementation) as unknown as typeof fetch
+
 // ---------------------------------------------------------------------------
 // gitHubConfigSchema
 // ---------------------------------------------------------------------------
@@ -88,7 +95,7 @@ describe('findExistingIssue()', () => {
   })
 
   test('returns issue number when found', async () => {
-    globalThis.fetch = mock(() =>
+    globalThis.fetch = mockFetch(() =>
       Promise.resolve(
         new Response(JSON.stringify({ items: [{ number: 42 }] }), {
           status: 200,
@@ -100,7 +107,7 @@ describe('findExistingIssue()', () => {
   })
 
   test('returns null when no matching issues', async () => {
-    globalThis.fetch = mock(() =>
+    globalThis.fetch = mockFetch(() =>
       Promise.resolve(
         new Response(JSON.stringify({ items: [] }), { status: 200 }),
       ),
@@ -110,7 +117,7 @@ describe('findExistingIssue()', () => {
   })
 
   test('returns null on non-ok response', async () => {
-    globalThis.fetch = mock(() =>
+    globalThis.fetch = mockFetch(() =>
       Promise.resolve(new Response('rate limited', { status: 403 })),
     )
     const result = await findExistingIssue(testConfig, 'auth > login')
@@ -119,7 +126,7 @@ describe('findExistingIssue()', () => {
 
   test('sends correct authorization header', async () => {
     let capturedHeaders: Headers | undefined
-    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+    globalThis.fetch = mockFetch((_url: string, init?: RequestInit) => {
       capturedHeaders = new Headers(init?.headers)
       return Promise.resolve(
         new Response(JSON.stringify({ items: [] }), { status: 200 }),
@@ -131,7 +138,7 @@ describe('findExistingIssue()', () => {
 
   test('encodes test name in search query', async () => {
     let capturedUrl = ''
-    globalThis.fetch = mock((url: string) => {
+    globalThis.fetch = mockFetch((url: string) => {
       capturedUrl = url
       return Promise.resolve(
         new Response(JSON.stringify({ items: [] }), { status: 200 }),
@@ -155,7 +162,7 @@ describe('createIssue()', () => {
   })
 
   test('returns issue URL on success', async () => {
-    globalThis.fetch = mock(() =>
+    globalThis.fetch = mockFetch(() =>
       Promise.resolve(
         new Response(
           JSON.stringify({
@@ -172,7 +179,7 @@ describe('createIssue()', () => {
   test('sends POST to correct endpoint', async () => {
     let capturedUrl = ''
     let capturedMethod = ''
-    globalThis.fetch = mock((url: string, init?: RequestInit) => {
+    globalThis.fetch = mockFetch((url: string, init?: RequestInit) => {
       capturedUrl = url
       capturedMethod = init?.method ?? ''
       return Promise.resolve(
@@ -190,7 +197,7 @@ describe('createIssue()', () => {
 
   test('includes flaky-test label', async () => {
     let capturedBody = ''
-    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+    globalThis.fetch = mockFetch((_url: string, init?: RequestInit) => {
       capturedBody = init?.body as string
       return Promise.resolve(
         new Response(JSON.stringify({ html_url: 'https://x' }), {
@@ -205,7 +212,7 @@ describe('createIssue()', () => {
 
   test('includes test name in title', async () => {
     let capturedBody = ''
-    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+    globalThis.fetch = mockFetch((_url: string, init?: RequestInit) => {
       capturedBody = init?.body as string
       return Promise.resolve(
         new Response(JSON.stringify({ html_url: 'https://x' }), {
@@ -219,7 +226,7 @@ describe('createIssue()', () => {
   })
 
   test('throws on non-ok response', async () => {
-    globalThis.fetch = mock(() =>
+    globalThis.fetch = mockFetch(() =>
       Promise.resolve(new Response('Validation Failed', { status: 422 })),
     )
     expect(createIssue(testConfig, makePattern(), 7)).rejects.toThrow(
@@ -229,7 +236,7 @@ describe('createIssue()', () => {
 
   test('includes investigation prompt in body', async () => {
     let capturedBody = ''
-    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+    globalThis.fetch = mockFetch((_url: string, init?: RequestInit) => {
       capturedBody = init?.body as string
       return Promise.resolve(
         new Response(JSON.stringify({ html_url: 'https://x' }), {

--- a/packages/cli/src/prompt.test.ts
+++ b/packages/cli/src/prompt.test.ts
@@ -67,7 +67,8 @@ describe('generatePrompt', () => {
   })
 
   test('multiple failure kinds joined with comma', () => {
-    const p = { ...base, failureKinds: ['timeout', 'assertion'] }
+    const failureKinds: FlakyPattern['failureKinds'] = ['timeout', 'assertion']
+    const p = { ...base, failureKinds }
     expect(generatePrompt(p)).toContain('timeout, assertion')
   })
 })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,5 +28,8 @@
   "license": "MIT",
   "dependencies": {
     "arktype": "^2.2.0"
+  },
+  "devDependencies": {
+    "bun-types": "latest"
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
   "include": ["src/**/*.ts"]
 }

--- a/packages/plugin-vitest/package.json
+++ b/packages/plugin-vitest/package.json
@@ -33,6 +33,7 @@
     "vitest": ">=1.0.0"
   },
   "devDependencies": {
-    "@types/node": "^25.6.0"
+    "@types/node": "^25.6.0",
+    "bun-types": "latest"
   }
 }

--- a/packages/plugin-vitest/src/index.test.ts
+++ b/packages/plugin-vitest/src/index.test.ts
@@ -61,7 +61,14 @@ function createMockStore(): { store: IStore; calls: StoreCalls } {
 // Task helpers (mimics Vitest task shape)
 // ---------------------------------------------------------------------------
 
-function makeTask(overrides: Record<string, unknown> = {}) {
+// Test doubles intentionally shaped loosely — the reporter treats tasks
+// as unknown and narrows via property checks. Cast to `any` at the boundary
+// so tests can mutate (e.g. assign `.suite` parent refs) without fighting
+// Vitest's strict `TaskBase` shape.
+// biome-ignore lint/suspicious/noExplicitAny: test doubles for vitest task tree
+type TestTask = any
+
+function makeTask(overrides: Record<string, unknown> = {}): TestTask {
   return {
     id: '1',
     name: 'test name',
@@ -72,7 +79,7 @@ function makeTask(overrides: Record<string, unknown> = {}) {
   }
 }
 
-function makeFileTask(tasks: unknown[] = []) {
+function makeFileTask(tasks: TestTask[] = []): TestTask {
   return {
     id: 'file-1',
     name: 'example.test.ts',
@@ -180,7 +187,7 @@ describe('FlakyTestsReporter', () => {
     const reporter = new FlakyTestsReporter(store)
     await reporter.onInit({})
 
-    const innerSuite = {
+    const innerSuite: TestTask = {
       id: 'suite-inner',
       name: 'inner',
       type: 'suite',
@@ -194,11 +201,11 @@ describe('FlakyTestsReporter', () => {
     // Set suite parent reference
     innerSuite.tasks[0].suite = innerSuite
 
-    const outerSuite = {
+    const outerSuite: TestTask = {
       id: 'suite-outer',
       name: 'outer',
       type: 'suite',
-      suite: undefined as unknown,
+      suite: undefined,
       tasks: [innerSuite],
     }
     innerSuite.suite = outerSuite

--- a/packages/plugin-vitest/tsconfig.json
+++ b/packages/plugin-vitest/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
   "include": ["src/**/*.ts"]
 }

--- a/packages/store-postgres/package.json
+++ b/packages/store-postgres/package.json
@@ -35,5 +35,8 @@
     "@flaky-tests/core": "workspace:*",
     "arktype": "^2.1.0",
     "postgres": "^3.4.0"
+  },
+  "devDependencies": {
+    "bun-types": "latest"
   }
 }

--- a/packages/store-postgres/src/index.integration.test.ts
+++ b/packages/store-postgres/src/index.integration.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import type { FailureKind } from '@flaky-tests/core'
 import { PostgresStore } from './index'
 
 const SKIP = !process.env.INTEGRATION || !process.env.POSTGRES_TEST_URL
@@ -30,7 +31,7 @@ function makeFailure(
   runId: string,
   testName: string,
   failedAt: Date,
-  kind = 'assertion' as const,
+  kind: FailureKind = 'assertion',
 ) {
   return {
     runId,

--- a/packages/store-postgres/tsconfig.json
+++ b/packages/store-postgres/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
   "include": ["src/**/*.ts"]
 }

--- a/packages/store-sqlite/src/index.test.ts
+++ b/packages/store-sqlite/src/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import type { FailureKind } from '@flaky-tests/core'
 import { SqliteStore } from './index'
 
 // Helpers ----------------------------------------------------------------
@@ -14,7 +15,7 @@ function makeFailure(
   runId: string,
   testName: string,
   failedAt: Date,
-  kind = 'assertion' as const,
+  kind: FailureKind = 'assertion',
 ) {
   return {
     runId,

--- a/packages/store-supabase/package.json
+++ b/packages/store-supabase/package.json
@@ -35,5 +35,8 @@
     "@flaky-tests/core": "workspace:*",
     "@supabase/supabase-js": "^2.0.0",
     "arktype": "^2.1.0"
+  },
+  "devDependencies": {
+    "bun-types": "latest"
   }
 }

--- a/packages/store-supabase/tsconfig.json
+++ b/packages/store-supabase/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
   "include": ["src/**/*.ts"]
 }

--- a/packages/store-turso/package.json
+++ b/packages/store-turso/package.json
@@ -35,5 +35,8 @@
     "@flaky-tests/core": "workspace:*",
     "@libsql/client": "^0.14.0",
     "arktype": "^2.1.0"
+  },
+  "devDependencies": {
+    "bun-types": "latest"
   }
 }

--- a/packages/store-turso/src/index.integration.test.ts
+++ b/packages/store-turso/src/index.integration.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import type { FailureKind } from '@flaky-tests/core'
 import { TursoStore } from './index'
 
 const SKIP = !process.env.INTEGRATION
@@ -24,7 +25,7 @@ function makeFailure(
   runId: string,
   testName: string,
   failedAt: Date,
-  kind = 'assertion' as const,
+  kind: FailureKind = 'assertion',
 ) {
   return {
     runId,

--- a/packages/store-turso/tsconfig.json
+++ b/packages/store-turso/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- Adds `bun run typecheck` (per-package `tsc --noEmit` loop) and wires it into `check.yml` between Lint and Build.
- `bun run build` only type-checks `tsconfig.build.json` (source only, no tests). This gate extends coverage to test files and surfaced **7 latent issues** that existed on main.

Item 2 of [`.local/plans/slop-pass-cherry-pick.md`](../tree/main/.local/plans/slop-pass-cherry-pick.md). Depends on item 1 (already merged) — benefits from `exactOptionalPropertyTypes` + `noUncheckedIndexedAccess` now being active.

## Fallout surfaced and fixed

| Area | Issue | Fix |
|---|---|---|
| 5 packages (core, plugin-vitest, store-postgres, store-supabase, store-turso) | `bun:test` imports only resolved at runtime — no `bun-types` in tsconfig | Added `"types": ["bun-types"]` + devDep |
| `github-api.test.ts` | Bun's `mock()` return lacks `preconnect` that `typeof fetch` demands | Added `mockFetch` helper casting through unknown |
| `prompt.test.ts` | `failureKinds: ['timeout', 'assertion']` widened to `string[]` | Typed literal as `FlakyPattern['failureKinds']` |
| `plugin-vitest/index.test.ts` | Test doubles too narrow for vitest's strict `TaskBase` | Typed helpers with local `TestTask = any` + biome-ignore comment |
| 3× `makeFailure` helpers | `kind = 'assertion' as const` pinned param to one literal | Widened to `kind: FailureKind = 'assertion'` |

## Test plan

- [x] `bun run typecheck` — all 8 packages clean
- [x] `bun run check` — biome clean
- [x] `bun run build` — all packages build
- [x] `bun test` — 209 pass / 0 fail
- [ ] CI Check workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)