### PR TITLE
feat: defensive hardening (github/preload/describe-stack/categorize)

### DIFF
--- a/packages/cli/src/github.ts
+++ b/packages/cli/src/github.ts
@@ -9,6 +9,46 @@ import type { FlakyPattern } from '@flaky-tests/core'
 import { type } from 'arktype'
 import { generatePrompt } from './prompt'
 
+/** Default network timeout for GitHub API calls. */
+const FETCH_TIMEOUT_MS = 15_000
+
+/** Max characters for an issue body — GitHub's documented hard limit is 65536. */
+const MAX_ISSUE_BODY_CHARS = 60_000
+
+/** Max characters echoed from an error response body — guards against leaking secrets via error messages. */
+const MAX_ERROR_BODY_CHARS = 500
+
+/**
+ * Valid GitHub owner/repo slug. Prevents path injection in
+ * `/repos/${owner}/${repo}/issues` — without validation, a crafted
+ * --repo argument could rewrite the request path.
+ */
+const OWNER_REPO_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/
+
+function isValidSlug(value: string): boolean {
+  return OWNER_REPO_PATTERN.test(value)
+}
+
+/** Fetch with an AbortSignal-based timeout. Rejects on timeout with a clear message. */
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs: number = FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`GitHub request timed out after ${timeoutMs}ms: ${url}`)
+    }
+    throw error
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 /** Authentication and target repository for GitHub API calls. */
 export const gitHubConfigSchema = type({
   token: type.string.atLeastLength(1),
@@ -29,7 +69,8 @@ export function resolveRepo(): { owner: string; repo: string } | null {
   const envRepo = process.env.GITHUB_REPOSITORY
   if (envRepo) {
     const [owner, repo] = envRepo.split('/')
-    if (owner && repo) return { owner, repo }
+    if (owner && repo && isValidSlug(owner) && isValidSlug(repo))
+      return { owner, repo }
   }
 
   // --repo flag
@@ -38,7 +79,8 @@ export function resolveRepo(): { owner: string; repo: string } | null {
     const value = process.argv[idx + 1]
     if (!value) return null
     const [owner, repo] = value.split('/')
-    if (owner && repo) return { owner, repo }
+    if (owner && repo && isValidSlug(owner) && isValidSlug(repo))
+      return { owner, repo }
   }
 
   // Parse git remote
@@ -52,7 +94,10 @@ export function resolveRepo(): { owner: string; repo: string } | null {
       const url = new TextDecoder().decode(result.stdout).trim()
       // https://github.com/owner/repo.git  or  git@github.com:owner/repo.git
       const match = url.match(/github\.com[/:]([^/]+)\/([^/.]+)/)
-      if (match?.[1] && match[2]) return { owner: match[1], repo: match[2] }
+      const owner = match?.[1]
+      const repo = match?.[2]
+      if (owner && repo && isValidSlug(owner) && isValidSlug(repo))
+        return { owner, repo }
     }
   } catch {
     // git not available
@@ -80,7 +125,7 @@ export async function findExistingIssue(
   const q = encodeURIComponent(
     `repo:${config.owner}/${config.repo} is:issue is:open "${title}" in:title`,
   )
-  const res = await fetch(
+  const res = await fetchWithTimeout(
     `https://api.github.com/search/issues?q=${q}&per_page=1`,
     {
       headers: githubHeaders(config.token),
@@ -97,21 +142,29 @@ export async function createIssue(
   pattern: FlakyPattern,
   windowDays: number,
 ): Promise<string> {
-  const res = await fetch(
+  if (!isValidSlug(config.owner) || !isValidSlug(config.repo)) {
+    throw new Error(`Invalid owner/repo slug: ${config.owner}/${config.repo}`)
+  }
+  const rawBody = issueBody(pattern, windowDays)
+  const body =
+    rawBody.length > MAX_ISSUE_BODY_CHARS
+      ? `${rawBody.slice(0, MAX_ISSUE_BODY_CHARS)}\n\n…(truncated)`
+      : rawBody
+  const res = await fetchWithTimeout(
     `https://api.github.com/repos/${config.owner}/${config.repo}/issues`,
     {
       method: 'POST',
       headers: githubHeaders(config.token),
       body: JSON.stringify({
         title: issueTitle(pattern.testName),
-        body: issueBody(pattern, windowDays),
+        body,
         labels: ['flaky-test'],
       }),
     },
   )
 
   if (!res.ok) {
-    const text = await res.text()
+    const text = (await res.text()).slice(0, MAX_ERROR_BODY_CHARS)
     throw new Error(`GitHub API error ${res.status}: ${text}`)
   }
 

--- a/packages/core/src/categorize.ts
+++ b/packages/core/src/categorize.ts
@@ -1,5 +1,32 @@
 import type { FailureKind } from './types'
 
+/** Cap on how much of `error.message` we scan — guards against regex-DoS on huge messages. */
+const MAX_MESSAGE_SCAN_LENGTH = 4096
+
+/** Word-boundary match — avoids false positives like `"documentout"`. */
+const TIMEOUT_MESSAGE_PATTERN = /\btimed? ?out\b/i
+
+/**
+ * Read a property via a try/catch — a frozen object or a Proxy with a
+ * throwing getter can make `in` / property access throw. Returns `undefined`
+ * on failure.
+ */
+function safeRead(target: object, key: string): unknown {
+  try {
+    return (target as Record<string, unknown>)[key]
+  } catch {
+    return undefined
+  }
+}
+
+function safeHasOwn(target: object, key: string): boolean {
+  try {
+    return key in target
+  } catch {
+    return false
+  }
+}
+
 /**
  * Classifies a thrown test error into a coarse category. The categories are
  * deliberately few — we want to answer "is this test timing out vs. a bad
@@ -12,14 +39,19 @@ export function categorizeError(error: unknown): FailureKind {
   if (!(error instanceof Error)) {
     return 'unknown'
   }
-  const message = error.message ?? ''
-  if (error.name === 'TimeoutError' || /timed? ?out/i.test(message)) {
+  const rawMessage =
+    typeof safeRead(error, 'message') === 'string'
+      ? (safeRead(error, 'message') as string)
+      : ''
+  const message = rawMessage.slice(0, MAX_MESSAGE_SCAN_LENGTH)
+  const name = safeRead(error, 'name')
+  if (name === 'TimeoutError' || TIMEOUT_MESSAGE_PATTERN.test(message)) {
     return 'timeout'
   }
   if (
-    error.name === 'AssertionError' ||
+    name === 'AssertionError' ||
     // Bun's `expect` attaches a `matcherResult` to failures
-    'matcherResult' in error ||
+    safeHasOwn(error, 'matcherResult') ||
     // Vitest / Jest expect error format
     message.startsWith('expect(received)')
   ) {

--- a/packages/core/src/describe-stack.ts
+++ b/packages/core/src/describe-stack.ts
@@ -5,16 +5,20 @@
  * Used by the Bun preload which must monkey-patch `describe` to track nesting.
  * Vitest and other frameworks expose suite paths natively.
  */
+/** Guard against accidental recursion pushing frames indefinitely. */
+export const MAX_DESCRIBE_DEPTH = 256
+
 export class DescribeStack {
   private frames: string[] = []
 
   /**
-   * Snapshot of the current frames. Used by the `describe` wrapper to capture
-   * the path at describe-call time (synchronous w.r.t. the outer body), then
-   * replay it via `runWithFrames` whenever the runtime executes the nested body.
+   * Frozen snapshot of the current frames. Used by the `describe` wrapper to
+   * capture the path at describe-call time (synchronous w.r.t. the outer body),
+   * then replay it via `runWithFrames` whenever the runtime executes the nested
+   * body. Returning a frozen copy prevents callers from mutating internal state.
    */
   get snapshot(): readonly string[] {
-    return this.frames
+    return Object.freeze([...this.frames])
   }
 
   /**
@@ -22,6 +26,11 @@ export class DescribeStack {
    * try/finally so a thrown describe body does not leave a dangling frame.
    */
   run<T>(name: string, body: () => T): T {
+    if (this.frames.length >= MAX_DESCRIBE_DEPTH) {
+      throw new RangeError(
+        `DescribeStack exceeded ${MAX_DESCRIBE_DEPTH} frames — likely accidental recursion`,
+      )
+    }
     this.frames.push(name)
     try {
       return body()
@@ -36,6 +45,11 @@ export class DescribeStack {
    * time, since Bun defers nested describe body execution.
    */
   runWithFrames<T>(frames: readonly string[], body: () => T): T {
+    if (frames.length > MAX_DESCRIBE_DEPTH) {
+      throw new RangeError(
+        `DescribeStack.runWithFrames exceeded ${MAX_DESCRIBE_DEPTH} frames`,
+      )
+    }
     const saved = this.frames
     this.frames = [...frames]
     try {

--- a/packages/plugin-bun/src/preload.ts
+++ b/packages/plugin-bun/src/preload.ts
@@ -40,6 +40,15 @@ type TestCallback = (...args: unknown[]) => unknown | Promise<unknown>
 type TestFn = (name: string, fn: TestCallback, timeout?: number) => unknown
 type DescribeFn = (name: string, body: () => void) => unknown
 
+/** Accept only safe characters from env-provided RUN_ID. */
+const RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
+
+/** Bound on stack lines scanned when resolving a test file — stacks can be huge. */
+const STACK_SCAN_MAX_LINES = 200
+
+/** Module-level idempotency guard — double-registration would double-count everything. */
+let installed = false
+
 /** Fire-and-forget an async side-effect that must never throw into the caller. */
 function safeVoid(label: string, effect: () => Promise<void>): void {
   effect().catch((error: unknown) =>
@@ -54,7 +63,10 @@ function safeVoid(label: string, effect: () => Promise<void>): void {
 function resolveTestFile(error: unknown): string {
   if (!(error instanceof Error) || typeof error.stack !== 'string')
     return 'unknown'
-  for (const line of error.stack.split('\n')) {
+  const lines = error.stack.split('\n')
+  const limit = Math.min(lines.length, STACK_SCAN_MAX_LINES)
+  for (let i = 0; i < limit; i++) {
+    const line = lines[i] ?? ''
     const match = line.match(/\(([^)]+\.(?:ts|tsx|js|jsx|mjs|cjs)):\d+:\d+\)/)
     if (!match) continue
     const file = match[1] ?? ''
@@ -72,11 +84,17 @@ function resolveTestFile(error: unknown): string {
  * @param store - Storage backend implementing {@link IStore} (e.g. SQLite, Supabase).
  */
 export function createPreload(store: IStore): void {
+  if (installed) {
+    console.warn('[flaky-tests] createPreload called twice — ignoring')
+    return
+  }
+  installed = true
+
   // Use a run id provided by run-tracked (so it can reconcile the row post-exit)
-  // or generate a fresh one.
+  // or generate a fresh one. Reject garbage from env.
   const providedRunId = process.env.FLAKY_TESTS_RUN_ID
   const runId =
-    providedRunId !== undefined && providedRunId.length > 0
+    providedRunId !== undefined && RUN_ID_PATTERN.test(providedRunId)
       ? providedRunId
       : crypto.randomUUID()
   const startedAt = new Date().toISOString()
@@ -221,7 +239,9 @@ export function createPreload(store: IStore): void {
   afterAll(async () => {
     const endedAt = new Date().toISOString()
     const durationMs = Math.round(performance.now() - startPerf)
-    const passedTests = testsRun - testsFailed
+    // Clamp against counter skew — e.g. a test throwing outside the wrapper
+    // could increment failures without a matching testsRun++.
+    const passedTests = Math.max(0, testsRun - testsFailed)
     const status: 'pass' | 'fail' =
       testsFailed > 0 || errorsBetweenTests > 0 ? 'fail' : 'pass'
 


### PR DESCRIPTION
Batches items 3–6 of [\`.local/plans/slop-pass-cherry-pick.md\`](../tree/main/.local/plans/slop-pass-cherry-pick.md). Each target is a small defensive add; together they close known failure modes.

## What changes

| File | Hardening |
|---|---|
| \`packages/cli/src/github.ts\` | slug regex (path-injection defense), fetchWithTimeout (15s default), 60 KB issue-body cap, 500-char error-body slice |
| \`packages/plugin-bun/src/preload.ts\` | module-level \`installed\` idempotency flag, RUN_ID regex validation, 200-line stack-scan bound, \`Math.max(0, …)\` on passedTests |
| \`packages/core/src/describe-stack.ts\` | MAX_DESCRIBE_DEPTH=256 with RangeError, frozen \`snapshot\` |
| \`packages/core/src/categorize.ts\` | 4 KB message scan cap, word-boundary timeout regex, safeRead/safeHasOwn for frozen/proxy objects |

Net change: **+138 / -19** across 4 files.

## Why batch

Plan's PR sequence table marks items 3–5 as \"S\" (<30 LOC each) and suggests bundling as one security-polish PR. Item 6 (categorize) is comparable in size. All four are independent — no shared state, no ordering required.

## Test plan

- [x] \`bun run check\` — biome clean
- [x] \`bun run typecheck\` — 8 packages clean
- [x] \`bun run build\` — all packages build
- [x] \`bun test\` — 208 pass / 0 fail / 27 skip

## Notes

- Out of scope (item 2 of the plan = CLI \`parseCliConfig\` + error classes): that's M-sized with real fallout in \`check.ts\`'s arg-parsing. Deferring to its own PR.
- Out of scope (item 9: \`debugWarn\`): plan marks as conditional — main already uses \`biome-ignore\` headers for console in plugins, so the silence-by-default property isn't a clear win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)