### PR TITLE
ci: make release workflow manual-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Switch `.github/workflows/release.yml` from `push: [main]` to `workflow_dispatch:` so releases require an explicit click.
- Changesets still accumulates version-bump PRs on every main merge — this change only gates the publish side.

## Why
Every merge to main was triggering a release attempt. That is noisy and risks unintended publishes when a PR lands with a changeset.

## Test plan
- [x] YAML diff is a single-trigger swap
- [ ] Trigger manually via Actions tab after merge to confirm it runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)