### PR TITLE
feat(core): add namespaced leveled logger

### DIFF
--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -31,6 +31,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { FlakyPattern, IStore } from '@flaky-tests/core'
 import {
+  createLogger,
   getNewPatternsOptionsSchema,
   MAX_CLI_ERROR_MESSAGE_LENGTH,
   parse,
@@ -46,12 +47,17 @@ import {
 import { generateHtml } from './html'
 import { copyToClipboard, generatePrompt } from './prompt'
 
+const log = createLogger('cli')
+
 /** Load the store implementation chosen by `FLAKY_TESTS_STORE`, deferring
  *  the import so users pay the dependency cost only for the backend they use. */
 async function resolveStore(): Promise<IStore> {
   const storeType = process.env.FLAKY_TESTS_STORE ?? 'sqlite'
   const connStr = process.env.FLAKY_TESTS_CONNECTION_STRING
   const authToken = process.env.FLAKY_TESTS_AUTH_TOKEN
+  log.debug(
+    `resolveStore: type=${storeType}, connectionString=${connStr ? 'set' : 'unset'}, authToken=${authToken ? 'set' : 'unset'}`,
+  )
 
   switch (storeType) {
     case 'turso': {

--- a/packages/cli/src/github.ts
+++ b/packages/cli/src/github.ts
@@ -6,8 +6,11 @@
 // biome-ignore-all lint/suspicious/noConsole: CLI tool
 
 import type { FlakyPattern } from '@flaky-tests/core'
+import { createLogger } from '@flaky-tests/core'
 import { type } from 'arktype'
 import { generatePrompt } from './prompt'
+
+const log = createLogger('cli:github')
 
 /** Default network timeout for GitHub API calls. */
 const FETCH_TIMEOUT_MS = 15_000
@@ -70,18 +73,24 @@ export function resolveRepo(): { owner: string; repo: string } | null {
   const envRepo = process.env.GITHUB_REPOSITORY
   if (envRepo) {
     const [owner, repo] = envRepo.split('/')
-    if (owner && repo && isValidSlug(owner) && isValidSlug(repo))
+    if (owner && repo && isValidSlug(owner) && isValidSlug(repo)) {
+      log.debug(
+        `resolveRepo: source=GITHUB_REPOSITORY, owner=${owner}, repo=${repo}`,
+      )
       return { owner, repo }
+    }
   }
 
   // --repo flag
-  const idx = process.argv.indexOf('--repo')
-  if (idx !== -1 && idx + 1 < process.argv.length) {
-    const value = process.argv[idx + 1]
+  const index = process.argv.indexOf('--repo')
+  if (index !== -1 && index + 1 < process.argv.length) {
+    const value = process.argv[index + 1]
     if (!value) return null
     const [owner, repo] = value.split('/')
-    if (owner && repo && isValidSlug(owner) && isValidSlug(repo))
+    if (owner && repo && isValidSlug(owner) && isValidSlug(repo)) {
+      log.debug(`resolveRepo: source=--repo flag, owner=${owner}, repo=${repo}`)
       return { owner, repo }
+    }
   }
 
   // Parse git remote
@@ -97,12 +106,20 @@ export function resolveRepo(): { owner: string; repo: string } | null {
       const match = url.match(/github\.com[/:]([^/]+)\/([^/.]+)/)
       const owner = match?.[1]
       const repo = match?.[2]
-      if (owner && repo && isValidSlug(owner) && isValidSlug(repo))
+      if (owner && repo && isValidSlug(owner) && isValidSlug(repo)) {
+        log.debug(
+          `resolveRepo: source=git remote, owner=${owner}, repo=${repo}`,
+        )
         return { owner, repo }
+      }
     }
   } catch {
     // git not available
   }
+
+  log.debug(
+    'resolveRepo: all sources failed (GITHUB_REPOSITORY, --repo flag, git remote)',
+  )
 
   return null
 }
@@ -128,11 +145,15 @@ export async function findExistingIssue(
   const q = encodeURIComponent(
     `repo:${config.owner}/${config.repo} is:issue is:open "${title}" in:title`,
   )
+  const start = performance.now()
   const res = await fetchWithTimeout(
     `https://api.github.com/search/issues?q=${q}&per_page=1`,
     {
       headers: githubHeaders(config.token),
     },
+  )
+  log.debug(
+    `findExistingIssue: ${res.status} in ${Math.round(performance.now() - start)}ms (testName=${testName})`,
   )
   if (!res.ok) return null
   const data = (await res.json()) as { items: Array<{ number: number }> }
@@ -153,6 +174,12 @@ export async function createIssue(
     rawBody.length > MAX_ISSUE_BODY_CHARS
       ? `${rawBody.slice(0, MAX_ISSUE_BODY_CHARS)}\n\n…(truncated)`
       : rawBody
+  if (rawBody.length > MAX_ISSUE_BODY_CHARS) {
+    log.debug(
+      `createIssue: body truncated from ${rawBody.length} to ${MAX_ISSUE_BODY_CHARS} chars`,
+    )
+  }
+  const start = performance.now()
   const res = await fetchWithTimeout(
     `https://api.github.com/repos/${config.owner}/${config.repo}/issues`,
     {
@@ -164,6 +191,9 @@ export async function createIssue(
         labels: ['flaky-test'],
       }),
     },
+  )
+  log.debug(
+    `createIssue: ${res.status} in ${Math.round(performance.now() - start)}ms (testName=${pattern.testName})`,
   )
 
   if (!res.ok) {

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -1,4 +1,7 @@
+import { createLogger } from './log'
 import type { GitInfo } from './types'
+
+const log = createLogger('core:git')
 
 /**
  * Runs a command and returns stdout as a string, or null on failure.
@@ -15,7 +18,12 @@ export type RunCommand = (command: string, args: string[]) => string | null
 export function captureGitInfo(runCommand: RunCommand): GitInfo {
   const sha = runCommand('git', ['rev-parse', 'HEAD'])
   const porcelain = runCommand('git', ['status', '--porcelain'])
-  if (sha === null) return { sha: null, dirty: null }
+  if (sha === null) {
+    log.debug(
+      'captureGitInfo: `git rev-parse HEAD` returned null (not a git repo, git unavailable, or command failed)',
+    )
+    return { sha: null, dirty: null }
+  }
   return {
     sha: sha.trim(),
     dirty: porcelain !== null && porcelain.trim().length > 0,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,12 @@ export { DescribeStack } from './describe-stack'
 export { StoreError } from './errors'
 export { captureGitInfo, type RunCommand } from './git'
 export { escapeHtml } from './html-utils'
+export {
+  createLogger,
+  type Logger,
+  type LogLevel,
+  resolveLogLevel,
+} from './log'
 export { mapRowToPattern, type PatternRow } from './pattern-mapper'
 export { generatePrompt } from './prompt'
 export {

--- a/packages/core/src/log.test.ts
+++ b/packages/core/src/log.test.ts
@@ -1,0 +1,134 @@
+// biome-ignore-all lint/suspicious/noConsole: this is the logger test — it must stub console
+
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { createLogger, resolveLogLevel } from './log'
+
+const originalEnv = process.env.FLAKY_TESTS_LOG
+
+afterEach(() => {
+  if (originalEnv === undefined) {
+    delete process.env.FLAKY_TESTS_LOG
+  } else {
+    process.env.FLAKY_TESTS_LOG = originalEnv
+  }
+  mock.restore()
+})
+
+describe('resolveLogLevel', () => {
+  test('defaults to warn when env is unset', () => {
+    delete process.env.FLAKY_TESTS_LOG
+    expect(resolveLogLevel()).toBe('warn')
+  })
+
+  test('reads each valid level from env', () => {
+    for (const level of ['silent', 'error', 'warn', 'debug'] as const) {
+      process.env.FLAKY_TESTS_LOG = level
+      expect(resolveLogLevel()).toBe(level)
+    }
+  })
+
+  test('is case-insensitive', () => {
+    process.env.FLAKY_TESTS_LOG = 'DEBUG'
+    expect(resolveLogLevel()).toBe('debug')
+  })
+
+  test('falls back to warn on garbage value', () => {
+    process.env.FLAKY_TESTS_LOG = 'loud'
+    expect(resolveLogLevel()).toBe('warn')
+  })
+})
+
+describe('createLogger', () => {
+  test('prefixes output with [flaky-tests:<namespace>]', () => {
+    process.env.FLAKY_TESTS_LOG = 'debug'
+    const warnSpy = mock(() => {})
+    const originalWarn = console.warn
+    console.warn = warnSpy
+    try {
+      createLogger('preload').warn('something happened')
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[flaky-tests:preload]',
+        'something happened',
+      )
+    } finally {
+      console.warn = originalWarn
+    }
+  })
+
+  test('silent level suppresses every method', () => {
+    process.env.FLAKY_TESTS_LOG = 'silent'
+    const spies = {
+      error: mock(() => {}),
+      warn: mock(() => {}),
+      log: mock(() => {}),
+    }
+    const original = {
+      error: console.error,
+      warn: console.warn,
+      log: console.log,
+    }
+    console.error = spies.error
+    console.warn = spies.warn
+    console.log = spies.log
+    try {
+      const logger = createLogger('ns')
+      logger.error('err')
+      logger.warn('warn')
+      logger.debug('debug')
+      expect(spies.error).not.toHaveBeenCalled()
+      expect(spies.warn).not.toHaveBeenCalled()
+      expect(spies.log).not.toHaveBeenCalled()
+    } finally {
+      console.error = original.error
+      console.warn = original.warn
+      console.log = original.log
+    }
+  })
+
+  test('warn level emits warn+error, suppresses debug', () => {
+    process.env.FLAKY_TESTS_LOG = 'warn'
+    const spies = {
+      error: mock(() => {}),
+      warn: mock(() => {}),
+      log: mock(() => {}),
+    }
+    const original = {
+      error: console.error,
+      warn: console.warn,
+      log: console.log,
+    }
+    console.error = spies.error
+    console.warn = spies.warn
+    console.log = spies.log
+    try {
+      const logger = createLogger('ns')
+      logger.error('err')
+      logger.warn('warn')
+      logger.debug('debug')
+      expect(spies.error).toHaveBeenCalledTimes(1)
+      expect(spies.warn).toHaveBeenCalledTimes(1)
+      expect(spies.log).not.toHaveBeenCalled()
+    } finally {
+      console.error = original.error
+      console.warn = original.warn
+      console.log = original.log
+    }
+  })
+
+  test('level change takes effect between calls (no re-import required)', () => {
+    const warnSpy = mock(() => {})
+    const originalWarn = console.warn
+    console.warn = warnSpy
+    try {
+      const logger = createLogger('ns')
+      process.env.FLAKY_TESTS_LOG = 'silent'
+      logger.warn('one')
+      process.env.FLAKY_TESTS_LOG = 'warn'
+      logger.warn('two')
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith('[flaky-tests:ns]', 'two')
+    } finally {
+      console.warn = originalWarn
+    }
+  })
+})

--- a/packages/core/src/log.ts
+++ b/packages/core/src/log.ts
@@ -1,0 +1,69 @@
+/**
+ * Tiny leveled logger for flaky-tests diagnostics.
+ *
+ * Covers the "library code should fail loudly when something's actually broken
+ * but stay quiet when everything's fine" case — stores and plugins use this
+ * for their catch-block warn/error calls. CLI user output (pattern summaries,
+ * `✓`/`✗` lines) is not logging and continues to use `console.*` directly.
+ *
+ * Level is resolved from `FLAKY_TESTS_LOG` on every log call so tests can
+ * toggle it without re-importing the module. Per the project's convention,
+ * logger code is the one place `process.env` may be read directly — it runs
+ * before any config parsing.
+ */
+
+// biome-ignore-all lint/suspicious/noConsole: this is the logger — it owns console.*
+
+/** Log severity. Levels are inclusive: `warn` emits warn+error, `debug` emits everything. */
+export type LogLevel = 'silent' | 'error' | 'warn' | 'debug'
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  debug: 3,
+}
+
+const DEFAULT_LEVEL: LogLevel = 'warn'
+
+/** Resolve the active level from env, falling back to the default. */
+export function resolveLogLevel(): LogLevel {
+  const value = process.env.FLAKY_TESTS_LOG?.toLowerCase()
+  if (
+    value === 'silent' ||
+    value === 'error' ||
+    value === 'warn' ||
+    value === 'debug'
+  ) {
+    return value
+  }
+  return DEFAULT_LEVEL
+}
+
+export interface Logger {
+  error(...args: unknown[]): void
+  warn(...args: unknown[]): void
+  debug(...args: unknown[]): void
+}
+
+/**
+ * Create a namespaced logger. The namespace renders as `[flaky-tests:<namespace>]`
+ * at the start of every line so messages from different subsystems are easy
+ * to pick out in a noisy test run.
+ */
+export function createLogger(namespace: string): Logger {
+  const prefix = `[flaky-tests:${namespace}]`
+  const active = (level: LogLevel): boolean =>
+    LEVEL_ORDER[level] <= LEVEL_ORDER[resolveLogLevel()]
+  return {
+    error: (...args) => {
+      if (active('error')) console.error(prefix, ...args)
+    },
+    warn: (...args) => {
+      if (active('warn')) console.warn(prefix, ...args)
+    },
+    debug: (...args) => {
+      if (active('debug')) console.log(prefix, ...args)
+    },
+  }
+}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["bun-types"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.test.ts"]

--- a/packages/plugin-bun/src/preload.ts
+++ b/packages/plugin-bun/src/preload.ts
@@ -60,8 +60,12 @@ function safeVoid(label: string, effect: () => Promise<void>): void {
  * first frame that isn't inside this package. Falls back to `'unknown'`.
  */
 function resolveTestFile(error: unknown): string {
-  if (!(error instanceof Error) || typeof error.stack !== 'string')
+  if (!(error instanceof Error) || typeof error.stack !== 'string') {
+    log.debug(
+      `resolveTestFile: fallback=unknown (reason=${error instanceof Error ? 'no stack' : 'non-Error throw'})`,
+    )
     return 'unknown'
+  }
   const lines = error.stack.split('\n')
   const limit = Math.min(lines.length, STACK_SCAN_MAX_LINES)
   for (let i = 0; i < limit; i++) {
@@ -72,6 +76,9 @@ function resolveTestFile(error: unknown): string {
     if (file.includes('/plugin-bun/')) continue
     return file
   }
+  log.debug(
+    `resolveTestFile: fallback=unknown (scanned ${limit} frames, no non-plugin frame found; first frame: ${lines[0]?.trim() ?? 'none'})`,
+  )
   return 'unknown'
 }
 
@@ -92,13 +99,15 @@ export function createPreload(store: IStore): void {
   // Use a run id provided by run-tracked (so it can reconcile the row post-exit)
   // or generate a fresh one. Reject garbage from env.
   const providedRunId = process.env.FLAKY_TESTS_RUN_ID
-  const runId =
+  const runIdFromEnv =
     providedRunId !== undefined && RUN_ID_PATTERN.test(providedRunId)
-      ? providedRunId
-      : crypto.randomUUID()
+  const runId = runIdFromEnv ? providedRunId : crypto.randomUUID()
   const startedAt = new Date().toISOString()
   const startPerf = performance.now()
   const git = captureGitInfo()
+  log.debug(
+    `createPreload: runId=${runId} (source=${runIdFromEnv ? 'FLAKY_TESTS_RUN_ID' : 'generated'}), gitSha=${git.sha ?? 'none'}, gitDirty=${git.dirty}, bunVersion=${Bun.version}`,
+  )
 
   safeVoid('insertRun', () =>
     store.insertRun(
@@ -252,6 +261,9 @@ export function createPreload(store: IStore): void {
     const passedTests = Math.max(0, testsRun - testsFailed)
     const status: 'pass' | 'fail' =
       testsFailed > 0 || errorsBetweenTests > 0 ? 'fail' : 'pass'
+    log.debug(
+      `afterAll: runId=${runId}, status=${status}, total=${testsRun}, passed=${passedTests}, failed=${testsFailed}, errorsBetweenTests=${errorsBetweenTests}, durationMs=${durationMs}`,
+    )
 
     await store
       .updateRun(

--- a/packages/plugin-bun/src/preload.ts
+++ b/packages/plugin-bun/src/preload.ts
@@ -19,13 +19,12 @@
  *   preload = ["./my-preload.ts"]
  */
 
-// biome-ignore-all lint/suspicious/noConsole: preload is dev tooling
-
 import * as bunTest from 'bun:test'
 import { afterAll, mock } from 'bun:test'
 import type { IStore } from '@flaky-tests/core'
 import {
   categorizeError,
+  createLogger,
   DescribeStack,
   extractMessage,
   extractStack,
@@ -35,6 +34,8 @@ import {
   updateRunInputSchema,
 } from '@flaky-tests/core'
 import { captureGitInfo } from './git'
+
+const log = createLogger('plugin-bun')
 
 type TestCallback = (...args: unknown[]) => unknown | Promise<unknown>
 type TestFn = (name: string, fn: TestCallback, timeout?: number) => unknown
@@ -51,9 +52,7 @@ let installed = false
 
 /** Fire-and-forget an async side-effect that must never throw into the caller. */
 function safeVoid(label: string, effect: () => Promise<void>): void {
-  effect().catch((error: unknown) =>
-    console.warn(`[flaky-tests] ${label}:`, error),
-  )
+  effect().catch((error: unknown) => log.warn(`${label}:`, error))
 }
 
 /**
@@ -85,7 +84,7 @@ function resolveTestFile(error: unknown): string {
  */
 export function createPreload(store: IStore): void {
   if (installed) {
-    console.warn('[flaky-tests] createPreload called twice — ignoring')
+    log.warn('createPreload called twice — ignoring')
     return
   }
   installed = true
@@ -241,7 +240,7 @@ export function createPreload(store: IStore): void {
       describe: wrapDescribe(bunTest.describe as unknown as DescribeFn),
     }))
   } catch (error) {
-    console.warn('[flaky-tests] monkey-patch bun:test failed:', error)
+    log.warn('monkey-patch bun:test failed:', error)
   }
 
   // Wired via `afterAll` — finalizes the run row with aggregate stats and closes the store.
@@ -267,10 +266,8 @@ export function createPreload(store: IStore): void {
           errorsBetweenTests,
         }),
       )
-      .catch((e: unknown) => console.warn('[flaky-tests] updateRun failed:', e))
+      .catch((e: unknown) => log.warn('updateRun failed:', e))
 
-    await store
-      .close()
-      .catch((e: unknown) => console.warn('[flaky-tests] close failed:', e))
+    await store.close().catch((e: unknown) => log.warn('close failed:', e))
   })
 }

--- a/packages/plugin-vitest/src/index.ts
+++ b/packages/plugin-vitest/src/index.ts
@@ -127,6 +127,9 @@ export class FlakyTestsReporter {
   async onInit(_ctx: unknown): Promise<void> {
     this.ready = true
     const git = captureGitInfo()
+    log.debug(
+      `onInit: runId=${this.runId}, gitSha=${git.sha ?? 'none'}, gitDirty=${git.dirty}, nodeVersion=${process.version}`,
+    )
     await this.store
       .insertRun(
         parse(insertRunInputSchema, {
@@ -192,6 +195,12 @@ export class FlakyTestsReporter {
       })
     }
 
+    const status = failedTests > 0 || errors.length > 0 ? 'fail' : 'pass'
+    const durationMs = Math.round(performance.now() - this.startTime)
+    log.debug(
+      `onFinished: runId=${this.runId}, status=${status}, total=${totalTests}, passed=${passedTests}, failed=${failedTests}, errorsBetweenTests=${errors.length}, durationMs=${durationMs}`,
+    )
+
     await this.store
       .insertFailures(failureInputs)
       .catch((e: unknown) => log.warn('insertFailures failed:', e))
@@ -201,8 +210,8 @@ export class FlakyTestsReporter {
         this.runId,
         parse(updateRunInputSchema, {
           endedAt: new Date().toISOString(),
-          durationMs: Math.round(performance.now() - this.startTime),
-          status: failedTests > 0 || errors.length > 0 ? 'fail' : 'pass',
+          durationMs,
+          status,
           totalTests,
           passedTests,
           failedTests,

--- a/packages/plugin-vitest/src/index.ts
+++ b/packages/plugin-vitest/src/index.ts
@@ -18,13 +18,12 @@
  *   })
  */
 
-// biome-ignore-all lint/suspicious/noConsole: reporter is dev tooling
-
 import { execFileSync } from 'node:child_process'
 import type { InsertFailureInput, IStore, RunCommand } from '@flaky-tests/core'
 import {
   captureGitInfo as captureGitInfoCore,
   categorizeError,
+  createLogger,
   extractMessage,
   extractStack,
   insertFailureInputSchema,
@@ -32,6 +31,8 @@ import {
   parse,
   updateRunInputSchema,
 } from '@flaky-tests/core'
+
+const log = createLogger('plugin-vitest')
 
 /** Synchronous subprocess runner injected into core git helpers; swallows errors so missing git never breaks the reporter. */
 const runCommand: RunCommand = (command, args) => {
@@ -137,7 +138,7 @@ export class FlakyTestsReporter {
           testArgs: process.argv.slice(2).join(' '),
         }),
       )
-      .catch((e: unknown) => console.warn('[flaky-tests] insertRun failed:', e))
+      .catch((e: unknown) => log.warn('insertRun failed:', e))
   }
 
   /**
@@ -193,9 +194,7 @@ export class FlakyTestsReporter {
 
     await this.store
       .insertFailures(failureInputs)
-      .catch((e: unknown) =>
-        console.warn('[flaky-tests] insertFailures failed:', e),
-      )
+      .catch((e: unknown) => log.warn('insertFailures failed:', e))
 
     await this.store
       .updateRun(
@@ -210,10 +209,8 @@ export class FlakyTestsReporter {
           errorsBetweenTests: errors.length,
         }),
       )
-      .catch((e: unknown) => console.warn('[flaky-tests] updateRun failed:', e))
+      .catch((e: unknown) => log.warn('updateRun failed:', e))
 
-    await this.store
-      .close()
-      .catch((e: unknown) => console.warn('[flaky-tests] close failed:', e))
+    await this.store.close().catch((e: unknown) => log.warn('close failed:', e))
   }
 }

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  createLogger,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   type FlakyPattern,
@@ -21,6 +22,8 @@ import {
 } from '@flaky-tests/core'
 import { type } from 'arktype'
 import postgres from 'postgres'
+
+const log = createLogger('store-postgres')
 
 /** Configuration for the PostgreSQL store. */
 export const postgresStoreOptionsSchema = type({
@@ -246,7 +249,11 @@ export class PostgresStore implements IStore {
       ORDER BY recent_fails DESC
     `
 
-    return parseArray(flakyPatternSchema, rows.map(mapRowToPattern))
+    const patterns = parseArray(flakyPatternSchema, rows.map(mapRowToPattern))
+    log.debug(
+      `getNewPatterns: windowDays=${windowDays}, threshold=${threshold}, returned=${patterns.length} patterns`,
+    )
+    return patterns
   }
 
   /** Gracefully close the underlying PostgreSQL connection pool. */

--- a/packages/store-sqlite/src/index.ts
+++ b/packages/store-sqlite/src/index.ts
@@ -98,6 +98,9 @@ export class SqliteStore implements IStore {
   constructor(options: SqliteStoreOptions = {}) {
     const validated = parse(sqliteStoreOptionsSchema, options)
     const dbPath = validated.dbPath ?? DEFAULT_DB_PATH
+    log.debug(
+      `SqliteStore: dbPath=${dbPath} (source=${validated.dbPath ? 'options' : 'default'})`,
+    )
     ensureDirectory(dbPath)
     this.db = new Database(dbPath, { create: true })
     this.db.exec('PRAGMA journal_mode = WAL')
@@ -314,7 +317,11 @@ export class SqliteStore implements IStore {
         threshold,
       )
 
-    return parseArray(flakyPatternSchema, rows.map(mapRowToPattern))
+    const patterns = parseArray(flakyPatternSchema, rows.map(mapRowToPattern))
+    log.debug(
+      `getNewPatterns: windowDays=${windowDays}, threshold=${threshold}, returned=${patterns.length} patterns`,
+    )
+    return patterns
   }
 
   /** Close the underlying SQLite connection. */

--- a/packages/store-sqlite/src/index.ts
+++ b/packages/store-sqlite/src/index.ts
@@ -1,6 +1,7 @@
 import { Database } from 'bun:sqlite'
 import { mkdirSync } from 'node:fs'
 import {
+  createLogger,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   type FlakyPattern,
@@ -21,6 +22,8 @@ import {
   updateRunInputSchema,
 } from '@flaky-tests/core'
 import { type } from 'arktype'
+
+const log = createLogger('store-sqlite')
 
 /** Configuration for the SQLite-backed flaky-tests store. */
 export const sqliteStoreOptionsSchema = type({
@@ -239,9 +242,8 @@ export class SqliteStore implements IStore {
         WHERE run_id = ?`,
       [runId],
     )
-    // biome-ignore lint/suspicious/noConsole: legitimate runtime warning for operator visibility
-    console.warn(
-      `[flaky-tests] Run ${runId} exited with failure but preload recorded status=pass. Overriding to fail.`,
+    log.warn(
+      `Run ${runId} exited with failure but preload recorded status=pass. Overriding to fail.`,
     )
   }
 

--- a/packages/store-supabase/src/index.ts
+++ b/packages/store-supabase/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  createLogger,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   type FlakyPattern,
@@ -22,6 +23,8 @@ import {
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createClient } from '@supabase/supabase-js'
 import { type } from 'arktype'
+
+const log = createLogger('store-supabase')
 
 /** Configuration for the Supabase store. */
 export const supabaseStoreOptionsSchema = type({
@@ -265,22 +268,28 @@ export class SupabaseStore implements IStore {
       }
     }
 
-    return parseArray(
+    const patterns = parseArray(
       flakyPatternSchema,
       [...map.values()]
-        .filter((e) => e.recentFails >= threshold && e.priorFails === 0)
+        .filter(
+          (entry) => entry.recentFails >= threshold && entry.priorFails === 0,
+        )
         .sort((a, b) => b.recentFails - a.recentFails)
-        .map((e) => ({
-          testFile: e.testFile,
-          testName: e.testName,
-          recentFails: e.recentFails,
-          priorFails: e.priorFails,
-          failureKinds: [...e.kinds],
-          lastErrorMessage: e.lastMsg,
-          lastErrorStack: e.lastStack,
-          lastFailed: e.lastFailed,
+        .map((entry) => ({
+          testFile: entry.testFile,
+          testName: entry.testName,
+          recentFails: entry.recentFails,
+          priorFails: entry.priorFails,
+          failureKinds: [...entry.kinds],
+          lastErrorMessage: entry.lastMsg,
+          lastErrorStack: entry.lastStack,
+          lastFailed: entry.lastFailed,
         })),
     )
+    log.debug(
+      `getNewPatterns: windowDays=${windowDays}, threshold=${threshold}, returned=${patterns.length} patterns`,
+    )
+    return patterns
   }
 
   /** No-op: the supabase-js client manages its HTTP connections internally and needs no teardown. Present to satisfy {@link IStore}. */

--- a/packages/store-turso/src/index.ts
+++ b/packages/store-turso/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  createLogger,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   type FlakyPattern,
@@ -22,6 +23,8 @@ import {
 import type { Client, InArgs } from '@libsql/client'
 import { createClient } from '@libsql/client'
 import { type } from 'arktype'
+
+const log = createLogger('store-turso')
 
 /** Configuration for the Turso (libSQL) store. */
 export const tursoStoreOptionsSchema = type({
@@ -253,10 +256,14 @@ export class TursoStore implements IStore {
     })
 
     // libsql Row type doesn't expose named fields — cast through unknown to PatternRow
-    return parseArray(
+    const patterns = parseArray(
       flakyPatternSchema,
-      result.rows.map((r) => mapRowToPattern(r as unknown as PatternRow)),
+      result.rows.map((row) => mapRowToPattern(row as unknown as PatternRow)),
     )
+    log.debug(
+      `getNewPatterns: windowDays=${windowDays}, threshold=${threshold}, returned=${patterns.length} patterns`,
+    )
+    return patterns
   }
 
   /** Close the underlying libSQL connection. */


### PR DESCRIPTION
Tiny in-repo logger in `@flaky-tests/core` — replaces 10 scattered `console.warn('[flaky-tests] ...')` call sites across plugins and stores with a single API.

## Why not pino/winston

The whole `@flaky-tests/core` package is smaller than pino's dep tree. JSON output is wrong for a dev-tool CLI whose primary output is human-readable. In the Bun preload (loads in every user's test process) a framework logger's startup cost is pure overhead for what averages ~2-3 warn lines per run.

## API

```ts
import { createLogger } from '@flaky-tests/core'
const log = createLogger('plugin-bun')
log.warn('updateRun failed:', error)
// stderr: [flaky-tests:plugin-bun] updateRun failed: Error: db down
```

Level via `FLAKY_TESTS_LOG=silent|error|warn|debug` (default `warn`). Resolved per-call so tests can toggle without re-importing.

## Migrated (10 sites)

| File | Count | Change |
|---|---|---|
| `plugin-bun/preload.ts` | 5 | `console.warn('[flaky-tests] X')` → `log.warn('X')` |
| `plugin-vitest/index.ts` | 4 | same |
| `store-sqlite/index.ts` | 1 | same |

Per-file `biome-ignore-all noConsole` headers removed from the three files — they no longer touch `console` directly.

## Kept as `console.*` (intentional)

- `cli/check.ts` — pattern summaries, `✓`/`✗` lines, `--prompt` output. Program output, not logs.
- `store-sqlite/report.ts` — standalone CLI.

## Tsconfig

`packages/core/tsconfig.build.json` gains `"types": ["bun-types"]` so the build sees `process` and `console` globals (the runtime tsconfig already had this).

## Test plan

- [x] `bun run check` — biome clean
- [x] `bun run typecheck` — 8 packages clean
- [x] `bun run build` + `bun run build:types`
- [x] `bun test` — 231 pass / 0 fail (+8 new logger tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)