### PR TITLE
feat: add debug logging across CLI, plugins, and stores

### DIFF
--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -31,6 +31,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { FlakyPattern, IStore } from '@flaky-tests/core'
 import {
+  createLogger,
   getNewPatternsOptionsSchema,
   MAX_CLI_ERROR_MESSAGE_LENGTH,
   parse,
@@ -46,12 +47,17 @@ import {
 import { generateHtml } from './html'
 import { copyToClipboard, generatePrompt } from './prompt'
 
+const log = createLogger('cli')
+
 /** Load the store implementation chosen by `FLAKY_TESTS_STORE`, deferring
  *  the import so users pay the dependency cost only for the backend they use. */
 async function resolveStore(): Promise<IStore> {
   const storeType = process.env.FLAKY_TESTS_STORE ?? 'sqlite'
   const connStr = process.env.FLAKY_TESTS_CONNECTION_STRING
   const authToken = process.env.FLAKY_TESTS_AUTH_TOKEN
+  log.debug(
+    `resolveStore: type=${storeType}, connectionString=${connStr ? 'set' : 'unset'}, authToken=${authToken ? 'set' : 'unset'}`,
+  )
 
   switch (storeType) {
     case 'turso': {

--- a/packages/cli/src/github.ts
+++ b/packages/cli/src/github.ts
@@ -6,8 +6,11 @@
 // biome-ignore-all lint/suspicious/noConsole: CLI tool
 
 import type { FlakyPattern } from '@flaky-tests/core'
+import { createLogger } from '@flaky-tests/core'
 import { type } from 'arktype'
 import { generatePrompt } from './prompt'
+
+const log = createLogger('cli:github')
 
 /** Default network timeout for GitHub API calls. */
 const FETCH_TIMEOUT_MS = 15_000
@@ -70,18 +73,24 @@ export function resolveRepo(): { owner: string; repo: string } | null {
   const envRepo = process.env.GITHUB_REPOSITORY
   if (envRepo) {
     const [owner, repo] = envRepo.split('/')
-    if (owner && repo && isValidSlug(owner) && isValidSlug(repo))
+    if (owner && repo && isValidSlug(owner) && isValidSlug(repo)) {
+      log.debug(
+        `resolveRepo: source=GITHUB_REPOSITORY, owner=${owner}, repo=${repo}`,
+      )
       return { owner, repo }
+    }
   }
 
   // --repo flag
-  const idx = process.argv.indexOf('--repo')
-  if (idx !== -1 && idx + 1 < process.argv.length) {
-    const value = process.argv[idx + 1]
+  const index = process.argv.indexOf('--repo')
+  if (index !== -1 && index + 1 < process.argv.length) {
+    const value = process.argv[index + 1]
     if (!value) return null
     const [owner, repo] = value.split('/')
-    if (owner && repo && isValidSlug(owner) && isValidSlug(repo))
+    if (owner && repo && isValidSlug(owner) && isValidSlug(repo)) {
+      log.debug(`resolveRepo: source=--repo flag, owner=${owner}, repo=${repo}`)
       return { owner, repo }
+    }
   }
 
   // Parse git remote
@@ -97,12 +106,20 @@ export function resolveRepo(): { owner: string; repo: string } | null {
       const match = url.match(/github\.com[/:]([^/]+)\/([^/.]+)/)
       const owner = match?.[1]
       const repo = match?.[2]
-      if (owner && repo && isValidSlug(owner) && isValidSlug(repo))
+      if (owner && repo && isValidSlug(owner) && isValidSlug(repo)) {
+        log.debug(
+          `resolveRepo: source=git remote, owner=${owner}, repo=${repo}`,
+        )
         return { owner, repo }
+      }
     }
   } catch {
     // git not available
   }
+
+  log.debug(
+    'resolveRepo: all sources failed (GITHUB_REPOSITORY, --repo flag, git remote)',
+  )
 
   return null
 }
@@ -128,11 +145,15 @@ export async function findExistingIssue(
   const q = encodeURIComponent(
     `repo:${config.owner}/${config.repo} is:issue is:open "${title}" in:title`,
   )
+  const start = performance.now()
   const res = await fetchWithTimeout(
     `https://api.github.com/search/issues?q=${q}&per_page=1`,
     {
       headers: githubHeaders(config.token),
     },
+  )
+  log.debug(
+    `findExistingIssue: ${res.status} in ${Math.round(performance.now() - start)}ms (testName=${testName})`,
   )
   if (!res.ok) return null
   const data = (await res.json()) as { items: Array<{ number: number }> }
@@ -153,6 +174,12 @@ export async function createIssue(
     rawBody.length > MAX_ISSUE_BODY_CHARS
       ? `${rawBody.slice(0, MAX_ISSUE_BODY_CHARS)}\n\n…(truncated)`
       : rawBody
+  if (rawBody.length > MAX_ISSUE_BODY_CHARS) {
+    log.debug(
+      `createIssue: body truncated from ${rawBody.length} to ${MAX_ISSUE_BODY_CHARS} chars`,
+    )
+  }
+  const start = performance.now()
   const res = await fetchWithTimeout(
     `https://api.github.com/repos/${config.owner}/${config.repo}/issues`,
     {
@@ -164,6 +191,9 @@ export async function createIssue(
         labels: ['flaky-test'],
       }),
     },
+  )
+  log.debug(
+    `createIssue: ${res.status} in ${Math.round(performance.now() - start)}ms (testName=${pattern.testName})`,
   )
 
   if (!res.ok) {

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -1,4 +1,7 @@
+import { createLogger } from './log'
 import type { GitInfo } from './types'
+
+const log = createLogger('core:git')
 
 /**
  * Runs a command and returns stdout as a string, or null on failure.
@@ -15,7 +18,12 @@ export type RunCommand = (command: string, args: string[]) => string | null
 export function captureGitInfo(runCommand: RunCommand): GitInfo {
   const sha = runCommand('git', ['rev-parse', 'HEAD'])
   const porcelain = runCommand('git', ['status', '--porcelain'])
-  if (sha === null) return { sha: null, dirty: null }
+  if (sha === null) {
+    log.debug(
+      'captureGitInfo: `git rev-parse HEAD` returned null (not a git repo, git unavailable, or command failed)',
+    )
+    return { sha: null, dirty: null }
+  }
   return {
     sha: sha.trim(),
     dirty: porcelain !== null && porcelain.trim().length > 0,

--- a/packages/plugin-bun/src/preload.ts
+++ b/packages/plugin-bun/src/preload.ts
@@ -60,8 +60,12 @@ function safeVoid(label: string, effect: () => Promise<void>): void {
  * first frame that isn't inside this package. Falls back to `'unknown'`.
  */
 function resolveTestFile(error: unknown): string {
-  if (!(error instanceof Error) || typeof error.stack !== 'string')
+  if (!(error instanceof Error) || typeof error.stack !== 'string') {
+    log.debug(
+      `resolveTestFile: fallback=unknown (reason=${error instanceof Error ? 'no stack' : 'non-Error throw'})`,
+    )
     return 'unknown'
+  }
   const lines = error.stack.split('\n')
   const limit = Math.min(lines.length, STACK_SCAN_MAX_LINES)
   for (let i = 0; i < limit; i++) {
@@ -72,6 +76,9 @@ function resolveTestFile(error: unknown): string {
     if (file.includes('/plugin-bun/')) continue
     return file
   }
+  log.debug(
+    `resolveTestFile: fallback=unknown (scanned ${limit} frames, no non-plugin frame found; first frame: ${lines[0]?.trim() ?? 'none'})`,
+  )
   return 'unknown'
 }
 
@@ -92,13 +99,15 @@ export function createPreload(store: IStore): void {
   // Use a run id provided by run-tracked (so it can reconcile the row post-exit)
   // or generate a fresh one. Reject garbage from env.
   const providedRunId = process.env.FLAKY_TESTS_RUN_ID
-  const runId =
+  const runIdFromEnv =
     providedRunId !== undefined && RUN_ID_PATTERN.test(providedRunId)
-      ? providedRunId
-      : crypto.randomUUID()
+  const runId = runIdFromEnv ? providedRunId : crypto.randomUUID()
   const startedAt = new Date().toISOString()
   const startPerf = performance.now()
   const git = captureGitInfo()
+  log.debug(
+    `createPreload: runId=${runId} (source=${runIdFromEnv ? 'FLAKY_TESTS_RUN_ID' : 'generated'}), gitSha=${git.sha ?? 'none'}, gitDirty=${git.dirty}, bunVersion=${Bun.version}`,
+  )
 
   safeVoid('insertRun', () =>
     store.insertRun(
@@ -252,6 +261,9 @@ export function createPreload(store: IStore): void {
     const passedTests = Math.max(0, testsRun - testsFailed)
     const status: 'pass' | 'fail' =
       testsFailed > 0 || errorsBetweenTests > 0 ? 'fail' : 'pass'
+    log.debug(
+      `afterAll: runId=${runId}, status=${status}, total=${testsRun}, passed=${passedTests}, failed=${testsFailed}, errorsBetweenTests=${errorsBetweenTests}, durationMs=${durationMs}`,
+    )
 
     await store
       .updateRun(

--- a/packages/plugin-vitest/src/index.ts
+++ b/packages/plugin-vitest/src/index.ts
@@ -127,6 +127,9 @@ export class FlakyTestsReporter {
   async onInit(_ctx: unknown): Promise<void> {
     this.ready = true
     const git = captureGitInfo()
+    log.debug(
+      `onInit: runId=${this.runId}, gitSha=${git.sha ?? 'none'}, gitDirty=${git.dirty}, nodeVersion=${process.version}`,
+    )
     await this.store
       .insertRun(
         parse(insertRunInputSchema, {
@@ -192,6 +195,12 @@ export class FlakyTestsReporter {
       })
     }
 
+    const status = failedTests > 0 || errors.length > 0 ? 'fail' : 'pass'
+    const durationMs = Math.round(performance.now() - this.startTime)
+    log.debug(
+      `onFinished: runId=${this.runId}, status=${status}, total=${totalTests}, passed=${passedTests}, failed=${failedTests}, errorsBetweenTests=${errors.length}, durationMs=${durationMs}`,
+    )
+
     await this.store
       .insertFailures(failureInputs)
       .catch((e: unknown) => log.warn('insertFailures failed:', e))
@@ -201,8 +210,8 @@ export class FlakyTestsReporter {
         this.runId,
         parse(updateRunInputSchema, {
           endedAt: new Date().toISOString(),
-          durationMs: Math.round(performance.now() - this.startTime),
-          status: failedTests > 0 || errors.length > 0 ? 'fail' : 'pass',
+          durationMs,
+          status,
           totalTests,
           passedTests,
           failedTests,

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  createLogger,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   type FlakyPattern,
@@ -21,6 +22,8 @@ import {
 } from '@flaky-tests/core'
 import { type } from 'arktype'
 import postgres from 'postgres'
+
+const log = createLogger('store-postgres')
 
 /** Configuration for the PostgreSQL store. */
 export const postgresStoreOptionsSchema = type({
@@ -246,7 +249,11 @@ export class PostgresStore implements IStore {
       ORDER BY recent_fails DESC
     `
 
-    return parseArray(flakyPatternSchema, rows.map(mapRowToPattern))
+    const patterns = parseArray(flakyPatternSchema, rows.map(mapRowToPattern))
+    log.debug(
+      `getNewPatterns: windowDays=${windowDays}, threshold=${threshold}, returned=${patterns.length} patterns`,
+    )
+    return patterns
   }
 
   /** Gracefully close the underlying PostgreSQL connection pool. */

--- a/packages/store-sqlite/src/index.ts
+++ b/packages/store-sqlite/src/index.ts
@@ -98,6 +98,9 @@ export class SqliteStore implements IStore {
   constructor(options: SqliteStoreOptions = {}) {
     const validated = parse(sqliteStoreOptionsSchema, options)
     const dbPath = validated.dbPath ?? DEFAULT_DB_PATH
+    log.debug(
+      `SqliteStore: dbPath=${dbPath} (source=${validated.dbPath ? 'options' : 'default'})`,
+    )
     ensureDirectory(dbPath)
     this.db = new Database(dbPath, { create: true })
     this.db.exec('PRAGMA journal_mode = WAL')
@@ -314,7 +317,11 @@ export class SqliteStore implements IStore {
         threshold,
       )
 
-    return parseArray(flakyPatternSchema, rows.map(mapRowToPattern))
+    const patterns = parseArray(flakyPatternSchema, rows.map(mapRowToPattern))
+    log.debug(
+      `getNewPatterns: windowDays=${windowDays}, threshold=${threshold}, returned=${patterns.length} patterns`,
+    )
+    return patterns
   }
 
   /** Close the underlying SQLite connection. */

--- a/packages/store-supabase/src/index.ts
+++ b/packages/store-supabase/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  createLogger,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   type FlakyPattern,
@@ -22,6 +23,8 @@ import {
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createClient } from '@supabase/supabase-js'
 import { type } from 'arktype'
+
+const log = createLogger('store-supabase')
 
 /** Configuration for the Supabase store. */
 export const supabaseStoreOptionsSchema = type({
@@ -265,22 +268,28 @@ export class SupabaseStore implements IStore {
       }
     }
 
-    return parseArray(
+    const patterns = parseArray(
       flakyPatternSchema,
       [...map.values()]
-        .filter((e) => e.recentFails >= threshold && e.priorFails === 0)
+        .filter(
+          (entry) => entry.recentFails >= threshold && entry.priorFails === 0,
+        )
         .sort((a, b) => b.recentFails - a.recentFails)
-        .map((e) => ({
-          testFile: e.testFile,
-          testName: e.testName,
-          recentFails: e.recentFails,
-          priorFails: e.priorFails,
-          failureKinds: [...e.kinds],
-          lastErrorMessage: e.lastMsg,
-          lastErrorStack: e.lastStack,
-          lastFailed: e.lastFailed,
+        .map((entry) => ({
+          testFile: entry.testFile,
+          testName: entry.testName,
+          recentFails: entry.recentFails,
+          priorFails: entry.priorFails,
+          failureKinds: [...entry.kinds],
+          lastErrorMessage: entry.lastMsg,
+          lastErrorStack: entry.lastStack,
+          lastFailed: entry.lastFailed,
         })),
     )
+    log.debug(
+      `getNewPatterns: windowDays=${windowDays}, threshold=${threshold}, returned=${patterns.length} patterns`,
+    )
+    return patterns
   }
 
   /** No-op: the supabase-js client manages its HTTP connections internally and needs no teardown. Present to satisfy {@link IStore}. */

--- a/packages/store-turso/src/index.ts
+++ b/packages/store-turso/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  createLogger,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   type FlakyPattern,
@@ -22,6 +23,8 @@ import {
 import type { Client, InArgs } from '@libsql/client'
 import { createClient } from '@libsql/client'
 import { type } from 'arktype'
+
+const log = createLogger('store-turso')
 
 /** Configuration for the Turso (libSQL) store. */
 export const tursoStoreOptionsSchema = type({
@@ -253,10 +256,14 @@ export class TursoStore implements IStore {
     })
 
     // libsql Row type doesn't expose named fields — cast through unknown to PatternRow
-    return parseArray(
+    const patterns = parseArray(
       flakyPatternSchema,
-      result.rows.map((r) => mapRowToPattern(r as unknown as PatternRow)),
+      result.rows.map((row) => mapRowToPattern(row as unknown as PatternRow)),
     )
+    log.debug(
+      `getNewPatterns: windowDays=${windowDays}, threshold=${threshold}, returned=${patterns.length} patterns`,
+    )
+    return patterns
   }
 
   /** Close the underlying libSQL connection. */


### PR DESCRIPTION
Stacked on #22 (feat/logger). Once that merges, this PR's base can be retargeted to main.

Adds `log.debug(...)` calls at the 12 highest-value troubleshooting points. Output is gated behind `FLAKY_TESTS_LOG=debug` — default is silent for these lines.

## Tier 1 — high-traffic confusion points

| Call site | Answers the question… |
|---|---|
| `cli/check.ts :: resolveStore` | "Why isn't my Turso store being used?" |
| `cli/github.ts :: resolveRepo` | "Which of the 3 repo-resolution sources won?" |
| `plugin-bun/preload.ts :: createPreload` | "Is it using my FLAKY_TESTS_RUN_ID or generating one?" |
| `plugin-bun afterAll` + `plugin-vitest onFinished` | "Why is it recording wrong counts?" |
| All 4 `store-*` `getNewPatterns` | "How many patterns came back, with what window/threshold?" |

## Tier 2 — nice to have

| Call site | Purpose |
|---|---|
| `store-sqlite` constructor | Resolved DB path + source (hits the "where is my DB on CI" question) |
| `cli/github.ts` findExistingIssue/createIssue | HTTP status + round-trip ms; also logs body truncation |
| `plugin-bun :: resolveTestFile` | Logs the 'unknown' fallback case with reason + first frame |
| `core/git.ts :: captureGitInfo` | Logs when `git rev-parse` returns null (not-a-repo vs git-unavailable) |

## Smoke verified

```
$ FLAKY_TESTS_LOG=debug bun packages/cli/src/check.ts --window 1 --threshold 5
[flaky-tests:cli] resolveStore: type=sqlite, connectionString=unset, authToken=unset
[flaky-tests:store-sqlite] SqliteStore: dbPath=... (source=options)
[flaky-tests:store-sqlite] getNewPatterns: windowDays=1, threshold=5, returned=0 patterns
✓ No new flaky test patterns detected (window: 1d, threshold: 5)
```

## Secret handling

`resolveStore` logs `connectionString=set|unset` and `authToken=set|unset` only — never the value. Connection strings can contain passwords/tokens across the three backends and there's no format-safe way to partially redact them, so we just confirm presence.

## Test plan

- [x] `bun run check` — biome clean
- [x] `bun run typecheck` — 8 packages clean
- [x] `bun run build` + `bun run build:types`
- [x] `bun test` — 231 pass / 0 fail
- [x] Smoke test with `FLAKY_TESTS_LOG=debug` — expected lines emitted
- [x] Smoke test without env var — no debug lines emitted (default behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)