### PR TITLE
refactor(core): unified config resolver + FlakyPlugin contract

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,8 @@
         "arktype": "^2.1.0",
       },
       "devDependencies": {
+        "@flaky-tests/plugin-bun": "workspace:*",
+        "@flaky-tests/plugin-vitest": "workspace:*",
         "bun-types": "latest",
       },
       "optionalDependencies": {
@@ -582,7 +584,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -1307,16 +1309,6 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@expressive-code/plugin-shiki/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
-
-    "@flaky-tests/core/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
-
-    "@flaky-tests/plugin-vitest/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
-
-    "@flaky-tests/store-postgres/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
-
-    "@flaky-tests/store-supabase/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
-
-    "@flaky-tests/store-turso/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,8 @@
     "@flaky-tests/store-postgres": "workspace:*"
   },
   "devDependencies": {
+    "@flaky-tests/plugin-bun": "workspace:*",
+    "@flaky-tests/plugin-vitest": "workspace:*",
     "bun-types": "latest"
   },
   "engines": {

--- a/packages/cli/src/args.test.ts
+++ b/packages/cli/src/args.test.ts
@@ -71,16 +71,16 @@ describe('parseCliConfig', () => {
   })
 
   test('recognizes --help and --version', () => {
-    expect(
-      parseCliConfig({ argv: ['--help'], defaults: DEFAULTS }).help,
-    ).toBe(true)
+    expect(parseCliConfig({ argv: ['--help'], defaults: DEFAULTS }).help).toBe(
+      true,
+    )
     expect(parseCliConfig({ argv: ['-h'], defaults: DEFAULTS }).help).toBe(true)
     expect(
       parseCliConfig({ argv: ['--version'], defaults: DEFAULTS }).version,
     ).toBe(true)
-    expect(
-      parseCliConfig({ argv: ['-v'], defaults: DEFAULTS }).version,
-    ).toBe(true)
+    expect(parseCliConfig({ argv: ['-v'], defaults: DEFAULTS }).version).toBe(
+      true,
+    )
   })
 
   test('captures --out and --repo when provided', () => {

--- a/packages/cli/src/args.test.ts
+++ b/packages/cli/src/args.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from 'bun:test'
 import { parseCliConfig } from './args'
 import { ConfigError } from './errors'
 
-const EMPTY_ENV: Record<string, string | undefined> = {}
+const DEFAULTS = { windowDays: 7, threshold: 2 }
 
 describe('parseCliConfig', () => {
-  test('defaults windowDays=7, threshold=2 when neither flag nor env set', () => {
-    const config = parseCliConfig({ argv: [], env: EMPTY_ENV })
+  test('uses defaults when no flags are set', () => {
+    const config = parseCliConfig({ argv: [], defaults: DEFAULTS })
     expect(config.windowDays).toBe(7)
     expect(config.threshold).toBe(2)
   })
@@ -14,75 +14,79 @@ describe('parseCliConfig', () => {
   test('reads --window and --threshold flags', () => {
     const config = parseCliConfig({
       argv: ['--window', '14', '--threshold', '5'],
-      env: EMPTY_ENV,
+      defaults: DEFAULTS,
     })
     expect(config.windowDays).toBe(14)
     expect(config.threshold).toBe(5)
   })
 
-  test('reads window/threshold from env when flags absent', () => {
+  test('uses injected defaults when flags absent', () => {
     const config = parseCliConfig({
       argv: [],
-      env: { FLAKY_TESTS_WINDOW: '21', FLAKY_TESTS_THRESHOLD: '4' },
+      defaults: { windowDays: 21, threshold: 4 },
     })
     expect(config.windowDays).toBe(21)
     expect(config.threshold).toBe(4)
   })
 
-  test('flag wins over env', () => {
+  test('flag wins over defaults', () => {
     const config = parseCliConfig({
       argv: ['--window', '3'],
-      env: { FLAKY_TESTS_WINDOW: '99' },
+      defaults: { windowDays: 99, threshold: 2 },
     })
     expect(config.windowDays).toBe(3)
   })
 
   test('throws ConfigError on non-numeric --window', () => {
     expect(() =>
-      parseCliConfig({ argv: ['--window', 'abc'], env: EMPTY_ENV }),
+      parseCliConfig({ argv: ['--window', 'abc'], defaults: DEFAULTS }),
     ).toThrow(ConfigError)
   })
 
   test('throws ConfigError on zero or negative --window', () => {
     expect(() =>
-      parseCliConfig({ argv: ['--window', '0'], env: EMPTY_ENV }),
+      parseCliConfig({ argv: ['--window', '0'], defaults: DEFAULTS }),
     ).toThrow(ConfigError)
     expect(() =>
-      parseCliConfig({ argv: ['--window', '-5'], env: EMPTY_ENV }),
+      parseCliConfig({ argv: ['--window', '-5'], defaults: DEFAULTS }),
     ).toThrow(ConfigError)
   })
 
   test('throws ConfigError on non-integer --threshold', () => {
     expect(() =>
-      parseCliConfig({ argv: ['--threshold', '2.5'], env: EMPTY_ENV }),
+      parseCliConfig({ argv: ['--threshold', '2.5'], defaults: DEFAULTS }),
     ).toThrow(ConfigError)
   })
 
   test('--copy implies showPrompts', () => {
-    const config = parseCliConfig({ argv: ['--copy'], env: EMPTY_ENV })
+    const config = parseCliConfig({ argv: ['--copy'], defaults: DEFAULTS })
     expect(config.doCopy).toBe(true)
     expect(config.showPrompts).toBe(true)
   })
 
   test('--prompt sets showPrompts without doCopy', () => {
-    const config = parseCliConfig({ argv: ['--prompt'], env: EMPTY_ENV })
+    const config = parseCliConfig({ argv: ['--prompt'], defaults: DEFAULTS })
     expect(config.showPrompts).toBe(true)
     expect(config.doCopy).toBe(false)
   })
 
   test('recognizes --help and --version', () => {
-    expect(parseCliConfig({ argv: ['--help'], env: EMPTY_ENV }).help).toBe(true)
-    expect(parseCliConfig({ argv: ['-h'], env: EMPTY_ENV }).help).toBe(true)
     expect(
-      parseCliConfig({ argv: ['--version'], env: EMPTY_ENV }).version,
+      parseCliConfig({ argv: ['--help'], defaults: DEFAULTS }).help,
     ).toBe(true)
-    expect(parseCliConfig({ argv: ['-v'], env: EMPTY_ENV }).version).toBe(true)
+    expect(parseCliConfig({ argv: ['-h'], defaults: DEFAULTS }).help).toBe(true)
+    expect(
+      parseCliConfig({ argv: ['--version'], defaults: DEFAULTS }).version,
+    ).toBe(true)
+    expect(
+      parseCliConfig({ argv: ['-v'], defaults: DEFAULTS }).version,
+    ).toBe(true)
   })
 
   test('captures --out and --repo when provided', () => {
     const config = parseCliConfig({
       argv: ['--html', '--out', 'report.html', '--repo', 'owner/name'],
-      env: EMPTY_ENV,
+      defaults: DEFAULTS,
     })
     expect(config.doHtml).toBe(true)
     expect(config.htmlOut).toBe('report.html')
@@ -90,7 +94,7 @@ describe('parseCliConfig', () => {
   })
 
   test('omits htmlOut/repo when flags absent', () => {
-    const config = parseCliConfig({ argv: [], env: EMPTY_ENV })
+    const config = parseCliConfig({ argv: [], defaults: DEFAULTS })
     expect(config.htmlOut).toBeUndefined()
     expect(config.repo).toBeUndefined()
   })
@@ -98,16 +102,18 @@ describe('parseCliConfig', () => {
   test('accepts fractional windowDays', () => {
     const config = parseCliConfig({
       argv: ['--window', '0.5'],
-      env: EMPTY_ENV,
+      defaults: DEFAULTS,
     })
     expect(config.windowDays).toBe(0.5)
   })
 })
 
 describe('CliError / ConfigError', () => {
-  test('ConfigError has exit code 2', async () => {
+  test('ConfigError is a named error re-exported from core', async () => {
     const { ConfigError: CE } = await import('./errors')
-    expect(new CE('bad').exitCode).toBe(2)
+    const error = new CE('bad')
+    expect(error.name).toBe('ConfigError')
+    expect(error.message).toBe('bad')
   })
   test('CliError default exit code 1', async () => {
     const { CliError: CLI } = await import('./errors')

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -6,6 +6,7 @@
  * keeps `check.ts` small.
  */
 
+import type { Config } from '@flaky-tests/core'
 import { type } from 'arktype'
 import { ConfigError } from './errors'
 
@@ -27,50 +28,61 @@ export type CliConfig = typeof cliConfigSchema.infer
 
 export interface ParseCliConfigOpts {
   argv: readonly string[]
-  env: Record<string, string | undefined>
+  /** Fallback values when argv flags are absent — sourced from the resolved {@link Config}. */
+  defaults: Pick<Config['detection'], 'windowDays' | 'threshold'>
 }
 
 /**
- * Parses argv and env into a validated {@link CliConfig}.
+ * Parses argv into a validated {@link CliConfig}, falling back to defaults
+ * from the resolved runtime config when flags are absent.
  *
  * Throws {@link ConfigError} (exit code 2) on invalid input so the caller
  * can surface a clean error without a stack trace.
  */
 export function parseCliConfig(opts: ParseCliConfigOpts): CliConfig {
-  const { argv, env } = opts
+  const { argv, defaults } = opts
 
   const hasFlag = (name: string): boolean =>
     argv.includes(`--${name}`) || argv.includes(`-${name.charAt(0)}`)
 
-  const option = (name: string, fallbackEnv?: string): string | undefined => {
+  const option = (name: string): string | undefined => {
     const index = argv.indexOf(`--${name}`)
     if (index !== -1 && index + 1 < argv.length) return argv[index + 1]
-    if (fallbackEnv !== undefined) return env[fallbackEnv]
     return undefined
   }
 
   const help = hasFlag('help')
   const version = hasFlag('version')
 
-  const rawWindow = option('window', 'FLAKY_TESTS_WINDOW') ?? '7'
-  const rawThreshold = option('threshold', 'FLAKY_TESTS_THRESHOLD') ?? '2'
+  const rawWindow = option('window')
+  const rawThreshold = option('threshold')
 
-  const windowDays = Number(rawWindow)
-  if (!Number.isFinite(windowDays) || windowDays <= 0) {
-    throw new ConfigError(
-      `--window must be a positive number, got "${rawWindow}"`,
-    )
+  let windowDays: number
+  if (rawWindow === undefined) {
+    windowDays = defaults.windowDays
+  } else {
+    windowDays = Number(rawWindow)
+    if (!Number.isFinite(windowDays) || windowDays <= 0) {
+      throw new ConfigError(
+        `--window must be a positive number, got "${rawWindow}"`,
+      )
+    }
   }
 
-  const threshold = Number(rawThreshold)
-  if (
-    !Number.isFinite(threshold) ||
-    threshold <= 0 ||
-    !Number.isInteger(threshold)
-  ) {
-    throw new ConfigError(
-      `--threshold must be a positive integer, got "${rawThreshold}"`,
-    )
+  let threshold: number
+  if (rawThreshold === undefined) {
+    threshold = defaults.threshold
+  } else {
+    threshold = Number(rawThreshold)
+    if (
+      !Number.isFinite(threshold) ||
+      threshold <= 0 ||
+      !Number.isInteger(threshold)
+    ) {
+      throw new ConfigError(
+        `--threshold must be a positive integer, got "${rawThreshold}"`,
+      )
+    }
   }
 
   const doCopy = hasFlag('copy')

--- a/packages/cli/src/check.ts
+++ b/packages/cli/src/check.ts
@@ -29,15 +29,16 @@
 import { writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import type { FlakyPattern, IStore } from '@flaky-tests/core'
+import type { Config, FlakyPattern, IStore } from '@flaky-tests/core'
 import {
   createLogger,
   getNewPatternsOptionsSchema,
   MAX_CLI_ERROR_MESSAGE_LENGTH,
   parse,
+  resolveConfig,
 } from '@flaky-tests/core'
 import { type CliConfig, parseCliConfig } from './args'
-import { CliError } from './errors'
+import { CliError, ConfigError } from './errors'
 import {
   createIssue,
   findExistingIssue,
@@ -49,46 +50,37 @@ import { copyToClipboard, generatePrompt } from './prompt'
 
 const log = createLogger('cli')
 
-/** Load the store implementation chosen by `FLAKY_TESTS_STORE`, deferring
- *  the import so users pay the dependency cost only for the backend they use. */
-async function resolveStore(): Promise<IStore> {
-  const storeType = process.env.FLAKY_TESTS_STORE ?? 'sqlite'
-  const connStr = process.env.FLAKY_TESTS_CONNECTION_STRING
-  const authToken = process.env.FLAKY_TESTS_AUTH_TOKEN
-  log.debug(
-    `resolveStore: type=${storeType}, connectionString=${connStr ? 'set' : 'unset'}, authToken=${authToken ? 'set' : 'unset'}`,
-  )
+/** Construct the store implementation for the resolved config's store variant.
+ *  Import is deferred so users pay the dependency cost only for the backend
+ *  they actually use. */
+async function resolveStore(config: Config): Promise<IStore> {
+  const { store } = config
+  log.debug(`resolveStore: type=${store.type}`)
 
-  switch (storeType) {
+  switch (store.type) {
     case 'turso': {
-      if (!connStr)
-        throw new Error(
-          'FLAKY_TESTS_CONNECTION_STRING is required for store=turso',
-        )
       const { TursoStore } = await import('@flaky-tests/store-turso')
       return new TursoStore({
-        url: connStr,
-        ...(authToken !== undefined && { authToken }),
+        url: store.url,
+        ...(store.authToken !== undefined && { authToken: store.authToken }),
       })
     }
     case 'supabase': {
-      if (!connStr || !authToken)
-        throw new Error(
-          'FLAKY_TESTS_CONNECTION_STRING and FLAKY_TESTS_AUTH_TOKEN are required for store=supabase',
-        )
       const { SupabaseStore } = await import('@flaky-tests/store-supabase')
-      return new SupabaseStore({ url: connStr, key: authToken })
+      return new SupabaseStore({ url: store.url, key: store.key })
     }
     case 'postgres': {
       const { PostgresStore } = await import('@flaky-tests/store-postgres')
       return new PostgresStore(
-        connStr !== undefined ? { connectionString: connStr } : {},
+        store.connectionString !== undefined
+          ? { connectionString: store.connectionString }
+          : {},
       )
     }
-    default: {
+    case 'sqlite': {
       const { SqliteStore } = await import('@flaky-tests/store-sqlite')
       return new SqliteStore({
-        dbPath: process.env.FLAKY_TESTS_DB ?? undefined,
+        ...(store.path !== undefined && { dbPath: store.path }),
       })
     }
   }
@@ -137,10 +129,13 @@ Examples:
 /** CLI entry point: runs detection, prints a human summary, and optionally
  *  prints prompts, copies to clipboard, opens GitHub issues, or writes an
  *  HTML report. Exits 1 when patterns are found so CI can gate on it. */
-async function main(config: CliConfig): Promise<void> {
+async function main(
+  cliConfig: CliConfig,
+  runtimeConfig: Config,
+): Promise<void> {
   const { windowDays, threshold, showPrompts, doCopy, doCreateIssue, doHtml } =
-    config
-  const store = await resolveStore()
+    cliConfig
+  const store = await resolveStore(runtimeConfig)
 
   let patterns: FlakyPattern[]
   try {
@@ -207,13 +202,13 @@ async function main(config: CliConfig): Promise<void> {
   }
 
   if (doCreateIssue) {
-    await openGitHubIssues(patterns, windowDays)
+    await openGitHubIssues(patterns, windowDays, runtimeConfig)
   }
 
   if (doHtml) {
     const html = generateHtml(patterns, windowDays)
     const outPath =
-      config.htmlOut ?? join(tmpdir(), `flaky-tests-${Date.now()}.html`)
+      cliConfig.htmlOut ?? join(tmpdir(), `flaky-tests-${Date.now()}.html`)
     writeFileSync(outPath, html, 'utf8')
     console.log(`✓ Report written to ${outPath}`)
 
@@ -238,14 +233,15 @@ async function main(config: CliConfig): Promise<void> {
 async function openGitHubIssues(
   patterns: FlakyPattern[],
   windowDays: number,
+  runtimeConfig: Config,
 ): Promise<void> {
-  const token = process.env.GITHUB_TOKEN
+  const token = runtimeConfig.github.token
   if (!token) {
     console.log('⚠ --create-issue requires GITHUB_TOKEN to be set\n')
     return
   }
 
-  const repoInfo = resolveRepo()
+  const repoInfo = resolveRepo(runtimeConfig)
   if (!repoInfo) {
     console.log(
       '⚠ --create-issue: could not determine owner/repo. Set GITHUB_REPOSITORY or pass --repo owner/repo\n',
@@ -277,19 +273,30 @@ async function openGitHubIssues(
 // --- Entry point ---------------------------------------------------------
 
 try {
-  const config = parseCliConfig({ argv: process.argv, env: process.env })
+  const runtimeConfig = resolveConfig()
+  const cliConfig = parseCliConfig({
+    argv: process.argv,
+    defaults: {
+      windowDays: runtimeConfig.detection.windowDays,
+      threshold: runtimeConfig.detection.threshold,
+    },
+  })
 
-  if (config.help) {
+  if (cliConfig.help) {
     console.log(HELP_TEXT)
     process.exit(0)
   }
-  if (config.version) {
+  if (cliConfig.version) {
     console.log(VERSION)
     process.exit(0)
   }
 
-  await main(config)
+  await main(cliConfig, runtimeConfig)
 } catch (error) {
+  if (error instanceof ConfigError) {
+    console.error(`error: ${error.message}`)
+    process.exit(2)
+  }
   if (error instanceof CliError) {
     console.error(`error: ${error.message}`)
     process.exit(error.exitCode)

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -5,6 +5,8 @@
  * so callers (CI pipelines) get a stable signal.
  */
 
+export { ConfigError } from '@flaky-tests/core'
+
 /** A CLI error the user should see. Default exit code: 1. */
 export class CliError extends Error {
   readonly exitCode: number
@@ -12,13 +14,5 @@ export class CliError extends Error {
     super(message)
     this.name = 'CliError'
     this.exitCode = exitCode
-  }
-}
-
-/** A configuration problem (bad flag, invalid env var). Exit code: 2. */
-export class ConfigError extends CliError {
-  constructor(message: string) {
-    super(message, 2)
-    this.name = 'ConfigError'
   }
 }

--- a/packages/cli/src/github.test.ts
+++ b/packages/cli/src/github.test.ts
@@ -1,36 +1,36 @@
+import type { Config } from '@flaky-tests/core'
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { resolveRepo } from './github'
 
+function configWithRepo(repository: string | undefined): Config {
+  return {
+    log: { level: 'warn' },
+    store: { type: 'sqlite' },
+    detection: { windowDays: 7, threshold: 2 },
+    github: repository !== undefined ? { repository } : {},
+    plugin: { disabled: false },
+    report: {},
+  } as Config
+}
+
 describe('resolveRepo', () => {
-  const originalEnv = process.env.GITHUB_REPOSITORY
   const originalArgv = [...process.argv]
 
   beforeEach(() => {
-    delete process.env.GITHUB_REPOSITORY
     process.argv = ['bun', 'check.ts']
   })
 
   afterEach(() => {
-    if (originalEnv !== undefined) {
-      process.env.GITHUB_REPOSITORY = originalEnv
-    } else {
-      delete process.env.GITHUB_REPOSITORY
-    }
     process.argv = originalArgv
   })
 
-  test('returns owner/repo from GITHUB_REPOSITORY env var', () => {
-    process.env.GITHUB_REPOSITORY = 'brewpirate/flaky-tests'
-    const result = resolveRepo()
+  test('returns owner/repo from config.github.repository', () => {
+    const result = resolveRepo(configWithRepo('brewpirate/flaky-tests'))
     expect(result).toEqual({ owner: 'brewpirate', repo: 'flaky-tests' })
   })
 
-  test('returns null for empty GITHUB_REPOSITORY', () => {
-    process.env.GITHUB_REPOSITORY = ''
-    // Falls through to --repo flag (not present) then git remote
-    const result = resolveRepo()
-    // Result depends on whether we're in a git repo with a github remote
-    // Just verify it doesn't throw
+  test('returns null/other source for empty repository', () => {
+    const result = resolveRepo(configWithRepo(''))
     expect(
       result === null || (result !== null && result.owner !== undefined),
     ).toBe(true)
@@ -38,21 +38,18 @@ describe('resolveRepo', () => {
 
   test('returns owner/repo from --repo flag', () => {
     process.argv = ['bun', 'check.ts', '--repo', 'octocat/hello-world']
-    const result = resolveRepo()
+    const result = resolveRepo(configWithRepo(undefined))
     expect(result).toEqual({ owner: 'octocat', repo: 'hello-world' })
   })
 
-  test('GITHUB_REPOSITORY takes precedence over --repo flag', () => {
-    process.env.GITHUB_REPOSITORY = 'env-owner/env-repo'
+  test('config.github.repository takes precedence over --repo flag', () => {
     process.argv = ['bun', 'check.ts', '--repo', 'flag-owner/flag-repo']
-    const result = resolveRepo()
+    const result = resolveRepo(configWithRepo('env-owner/env-repo'))
     expect(result).toEqual({ owner: 'env-owner', repo: 'env-repo' })
   })
 
-  test('falls back to git remote when no env or flag', () => {
-    // We're running inside the flaky-tests repo, so git remote should work
+  test('falls back to git remote when no config or flag', () => {
     const result = resolveRepo()
-    // Should resolve to this repo's remote (or null if git unavailable)
     if (result !== null) {
       expect(result.owner).toBeString()
       expect(result.repo).toBeString()
@@ -61,11 +58,8 @@ describe('resolveRepo', () => {
     }
   })
 
-  test('handles malformed GITHUB_REPOSITORY gracefully', () => {
-    process.env.GITHUB_REPOSITORY = 'no-slash-here'
-    // Falls through to other methods
-    const result = resolveRepo()
-    // Should not throw, may return from git remote or null
+  test('handles malformed repository string gracefully', () => {
+    const result = resolveRepo(configWithRepo('no-slash-here'))
     expect(result === null || typeof result === 'object').toBe(true)
   })
 })

--- a/packages/cli/src/github.test.ts
+++ b/packages/cli/src/github.test.ts
@@ -1,5 +1,5 @@
-import type { Config } from '@flaky-tests/core'
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import type { Config } from '@flaky-tests/core'
 import { resolveRepo } from './github'
 
 function configWithRepo(repository: string | undefined): Config {

--- a/packages/cli/src/github.ts
+++ b/packages/cli/src/github.ts
@@ -5,7 +5,7 @@
 
 // biome-ignore-all lint/suspicious/noConsole: CLI tool
 
-import type { FlakyPattern } from '@flaky-tests/core'
+import type { Config, FlakyPattern } from '@flaky-tests/core'
 import { createLogger } from '@flaky-tests/core'
 import { type } from 'arktype'
 import { generatePrompt } from './prompt'
@@ -64,13 +64,14 @@ export type GitHubConfig = typeof gitHubConfigSchema.infer
 
 /**
  * Resolve owner/repo from:
- *   1. GITHUB_REPOSITORY env var (set automatically in Actions)
+ *   1. `config.github.repository` (sourced from GITHUB_REPOSITORY — set automatically in Actions)
  *   2. --repo <owner/repo> CLI flag
  *   3. git remote origin URL (fallback for local runs)
  */
-export function resolveRepo(): { owner: string; repo: string } | null {
-  // GitHub Actions sets this automatically
-  const envRepo = process.env.GITHUB_REPOSITORY
+export function resolveRepo(
+  config?: Config,
+): { owner: string; repo: string } | null {
+  const envRepo = config?.github.repository
   if (envRepo) {
     const [owner, repo] = envRepo.split('/')
     if (owner && repo && isValidSlug(owner) && isValidSlug(repo)) {

--- a/packages/cli/src/plugin-registry.test.ts
+++ b/packages/cli/src/plugin-registry.test.ts
@@ -5,6 +5,7 @@
  * into documentation.
  */
 
+import { describe, expect, test } from 'bun:test'
 import { listRegisteredPlugins } from '@flaky-tests/core'
 import { bunPlugin } from '@flaky-tests/plugin-bun'
 import { vitestPlugin } from '@flaky-tests/plugin-vitest'
@@ -12,7 +13,6 @@ import { postgresStorePlugin } from '@flaky-tests/store-postgres'
 import { sqliteStorePlugin } from '@flaky-tests/store-sqlite'
 import { supabaseStorePlugin } from '@flaky-tests/store-supabase'
 import { tursoStorePlugin } from '@flaky-tests/store-turso'
-import { describe, expect, test } from 'bun:test'
 
 const EXPECTED_NAMES = [
   'plugin-bun',

--- a/packages/cli/src/plugin-registry.test.ts
+++ b/packages/cli/src/plugin-registry.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Registry-completeness guard: importing every plugin and store entrypoint
+ * must register its descriptor. Fails loudly if a package drops its
+ * `definePlugin(...)` call, so `name` stays a contract rather than rotting
+ * into documentation.
+ */
+
+import { listRegisteredPlugins } from '@flaky-tests/core'
+import { bunPlugin } from '@flaky-tests/plugin-bun'
+import { vitestPlugin } from '@flaky-tests/plugin-vitest'
+import { postgresStorePlugin } from '@flaky-tests/store-postgres'
+import { sqliteStorePlugin } from '@flaky-tests/store-sqlite'
+import { supabaseStorePlugin } from '@flaky-tests/store-supabase'
+import { tursoStorePlugin } from '@flaky-tests/store-turso'
+import { describe, expect, test } from 'bun:test'
+
+const EXPECTED_NAMES = [
+  'plugin-bun',
+  'plugin-vitest',
+  'store-sqlite',
+  'store-turso',
+  'store-supabase',
+  'store-postgres',
+]
+
+describe('plugin registry', () => {
+  test('every plugin and store package registers on import', () => {
+    void bunPlugin
+    void vitestPlugin
+    void sqliteStorePlugin
+    void tursoStorePlugin
+    void supabaseStorePlugin
+    void postgresStorePlugin
+
+    const registered = listRegisteredPlugins().map((plugin) => plugin.name)
+    for (const name of EXPECTED_NAMES) {
+      expect(registered).toContain(name)
+    }
+  })
+})

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import { ConfigError } from './errors'
 import { resolveConfig } from './config'
+import { ConfigError } from './errors'
 
 function env(overrides: Record<string, string | undefined>): NodeJS.ProcessEnv {
   return overrides as NodeJS.ProcessEnv
@@ -68,27 +68,27 @@ describe('resolveConfig', () => {
   })
 
   test('unknown store type throws ConfigError', () => {
-    expect(() =>
-      resolveConfig(env({ FLAKY_TESTS_STORE: 'dynamo' })),
-    ).toThrow(ConfigError)
+    expect(() => resolveConfig(env({ FLAKY_TESTS_STORE: 'dynamo' }))).toThrow(
+      ConfigError,
+    )
   })
 
   test('invalid window/threshold values throw ConfigError', () => {
-    expect(() =>
-      resolveConfig(env({ FLAKY_TESTS_WINDOW: 'abc' })),
-    ).toThrow(ConfigError)
-    expect(() =>
-      resolveConfig(env({ FLAKY_TESTS_THRESHOLD: '0' })),
-    ).toThrow(ConfigError)
-    expect(() =>
-      resolveConfig(env({ FLAKY_TESTS_THRESHOLD: '1.5' })),
-    ).toThrow(ConfigError)
+    expect(() => resolveConfig(env({ FLAKY_TESTS_WINDOW: 'abc' }))).toThrow(
+      ConfigError,
+    )
+    expect(() => resolveConfig(env({ FLAKY_TESTS_THRESHOLD: '0' }))).toThrow(
+      ConfigError,
+    )
+    expect(() => resolveConfig(env({ FLAKY_TESTS_THRESHOLD: '1.5' }))).toThrow(
+      ConfigError,
+    )
   })
 
   test('parses FLAKY_TESTS_DISABLE as boolean', () => {
-    expect(resolveConfig(env({ FLAKY_TESTS_DISABLE: '1' })).plugin.disabled).toBe(
-      true,
-    )
+    expect(
+      resolveConfig(env({ FLAKY_TESTS_DISABLE: '1' })).plugin.disabled,
+    ).toBe(true)
     expect(
       resolveConfig(env({ FLAKY_TESTS_DISABLE: 'true' })).plugin.disabled,
     ).toBe(true)

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test'
+import { ConfigError } from './errors'
+import { resolveConfig } from './config'
+
+function env(overrides: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return overrides as NodeJS.ProcessEnv
+}
+
+describe('resolveConfig', () => {
+  test('applies defaults when env is empty', () => {
+    const config = resolveConfig(env({}))
+    expect(config.log.level).toBe('warn')
+    expect(config.store).toEqual({ type: 'sqlite' })
+    expect(config.detection.windowDays).toBe(7)
+    expect(config.detection.threshold).toBe(2)
+    expect(config.plugin.disabled).toBe(false)
+    expect(config.github.token).toBeUndefined()
+    expect(config.report.browser).toBeUndefined()
+  })
+
+  test('maps FLAKY_TESTS_LOG to log.level (case-insensitive)', () => {
+    expect(resolveConfig(env({ FLAKY_TESTS_LOG: 'DEBUG' })).log.level).toBe(
+      'debug',
+    )
+    expect(resolveConfig(env({ FLAKY_TESTS_LOG: 'silent' })).log.level).toBe(
+      'silent',
+    )
+  })
+
+  test('maps sqlite store with optional path', () => {
+    const config = resolveConfig(env({ FLAKY_TESTS_DB: '/tmp/x.db' }))
+    expect(config.store).toEqual({ type: 'sqlite', path: '/tmp/x.db' })
+  })
+
+  test('maps turso store with required url + optional token', () => {
+    const config = resolveConfig(
+      env({
+        FLAKY_TESTS_STORE: 'turso',
+        FLAKY_TESTS_CONNECTION_STRING: 'libsql://x.turso.io',
+        FLAKY_TESTS_AUTH_TOKEN: 'tok',
+      }),
+    )
+    expect(config.store).toEqual({
+      type: 'turso',
+      url: 'libsql://x.turso.io',
+      authToken: 'tok',
+    })
+  })
+
+  test('turso store requires connection string', () => {
+    expect(() => resolveConfig(env({ FLAKY_TESTS_STORE: 'turso' }))).toThrow(
+      ConfigError,
+    )
+  })
+
+  test('supabase store requires both url and key', () => {
+    expect(() => resolveConfig(env({ FLAKY_TESTS_STORE: 'supabase' }))).toThrow(
+      ConfigError,
+    )
+    expect(() =>
+      resolveConfig(
+        env({
+          FLAKY_TESTS_STORE: 'supabase',
+          FLAKY_TESTS_CONNECTION_STRING: 'https://x.supabase.co',
+        }),
+      ),
+    ).toThrow(ConfigError)
+  })
+
+  test('unknown store type throws ConfigError', () => {
+    expect(() =>
+      resolveConfig(env({ FLAKY_TESTS_STORE: 'dynamo' })),
+    ).toThrow(ConfigError)
+  })
+
+  test('invalid window/threshold values throw ConfigError', () => {
+    expect(() =>
+      resolveConfig(env({ FLAKY_TESTS_WINDOW: 'abc' })),
+    ).toThrow(ConfigError)
+    expect(() =>
+      resolveConfig(env({ FLAKY_TESTS_THRESHOLD: '0' })),
+    ).toThrow(ConfigError)
+    expect(() =>
+      resolveConfig(env({ FLAKY_TESTS_THRESHOLD: '1.5' })),
+    ).toThrow(ConfigError)
+  })
+
+  test('parses FLAKY_TESTS_DISABLE as boolean', () => {
+    expect(resolveConfig(env({ FLAKY_TESTS_DISABLE: '1' })).plugin.disabled).toBe(
+      true,
+    )
+    expect(
+      resolveConfig(env({ FLAKY_TESTS_DISABLE: 'true' })).plugin.disabled,
+    ).toBe(true)
+    expect(
+      resolveConfig(env({ FLAKY_TESTS_DISABLE: 'no' })).plugin.disabled,
+    ).toBe(false)
+  })
+
+  test('folds ambient env vars into config', () => {
+    const config = resolveConfig(
+      env({
+        GITHUB_TOKEN: 'ghp_x',
+        GITHUB_REPOSITORY: 'owner/repo',
+        FLAKY_TESTS_RUN_ID: 'run-abc',
+        BROWSER: 'firefox',
+      }),
+    )
+    expect(config.github).toEqual({ token: 'ghp_x', repository: 'owner/repo' })
+    expect(config.plugin.runIdOverride).toBe('run-abc')
+    expect(config.report.browser).toBe('firefox')
+  })
+})

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,0 +1,306 @@
+/**
+ * Unified runtime configuration for flaky-tests.
+ *
+ * This module is the ONLY place in the codebase that reads `process.env`.
+ * Every other caller goes through `resolveConfig()`. One narrow exception
+ * lives in `plugin-bun/src/run-tracked.ts`, which *writes* FLAKY_TESTS_RUN_ID
+ * as IPC to its `bun test` child — that is not a config read.
+ */
+
+import { type } from 'arktype'
+import { ConfigError } from './errors'
+import { parse } from './validate-schemas'
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const logLevel = type("'silent' | 'error' | 'warn' | 'debug'")
+
+const sqliteStoreConfigSchema = type({
+  type: "'sqlite'",
+  'path?': 'string',
+})
+
+const tursoStoreConfigSchema = type({
+  type: "'turso'",
+  url: type.string.atLeastLength(1),
+  'authToken?': 'string',
+})
+
+const supabaseStoreConfigSchema = type({
+  type: "'supabase'",
+  url: type.string.atLeastLength(1),
+  key: type.string.atLeastLength(1),
+  'tablePrefix?': 'string',
+})
+
+const postgresStoreConfigSchema = type({
+  type: "'postgres'",
+  'connectionString?': 'string',
+  'host?': 'string',
+  'port?': 'number.integer > 0',
+  'database?': 'string',
+  'username?': 'string',
+  'password?': 'string',
+  'ssl?': "boolean | 'require' | 'prefer' | 'allow'",
+  'tablePrefix?': 'string',
+})
+
+/** Discriminated union on `type` — each variant carries only its own fields. */
+export const storeConfigSchema = sqliteStoreConfigSchema
+  .or(tursoStoreConfigSchema)
+  .or(supabaseStoreConfigSchema)
+  .or(postgresStoreConfigSchema)
+
+export const configSchema = type({
+  log: { level: logLevel },
+  store: storeConfigSchema,
+  detection: {
+    windowDays: 'number > 0',
+    threshold: 'number.integer > 0',
+  },
+  github: {
+    'token?': 'string',
+    'repository?': 'string',
+  },
+  plugin: {
+    disabled: 'boolean',
+    'runIdOverride?': 'string',
+  },
+  report: {
+    'browser?': 'string',
+  },
+})
+
+export type Config = typeof configSchema.infer
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+const DEFAULT_WINDOW_DAYS = 7
+const DEFAULT_THRESHOLD = 2
+
+function parseBoolean(value: string | undefined): boolean {
+  return value === '1' || value === 'true'
+}
+
+function parsePositiveNumber(
+  value: string | undefined,
+  fallback: number,
+  label: string,
+): number {
+  if (value === undefined || value === '') return fallback
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new ConfigError(`${label} must be a positive number, got "${value}"`)
+  }
+  return parsed
+}
+
+function parsePositiveInt(
+  value: string | undefined,
+  fallback: number,
+  label: string,
+): number {
+  if (value === undefined || value === '') return fallback
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+    throw new ConfigError(`${label} must be a positive integer, got "${value}"`)
+  }
+  return parsed
+}
+
+function resolveLogLevelValue(value: string | undefined): Config['log']['level'] {
+  const lowered = value?.toLowerCase()
+  if (
+    lowered === 'silent' ||
+    lowered === 'error' ||
+    lowered === 'warn' ||
+    lowered === 'debug'
+  ) {
+    return lowered
+  }
+  return 'warn'
+}
+
+function resolveStoreConfig(
+  env: NodeJS.ProcessEnv,
+): Config['store'] {
+  const storeType = env.FLAKY_TESTS_STORE ?? 'sqlite'
+  const connectionString = env.FLAKY_TESTS_CONNECTION_STRING
+  const authToken = env.FLAKY_TESTS_AUTH_TOKEN
+
+  switch (storeType) {
+    case 'sqlite': {
+      const dbPath = env.FLAKY_TESTS_DB
+      return {
+        type: 'sqlite',
+        ...(dbPath !== undefined && { path: dbPath }),
+      }
+    }
+    case 'turso': {
+      if (!connectionString) {
+        throw new ConfigError(
+          'FLAKY_TESTS_CONNECTION_STRING is required for store=turso',
+        )
+      }
+      return {
+        type: 'turso',
+        url: connectionString,
+        ...(authToken !== undefined && { authToken }),
+      }
+    }
+    case 'supabase': {
+      if (!connectionString || !authToken) {
+        throw new ConfigError(
+          'FLAKY_TESTS_CONNECTION_STRING and FLAKY_TESTS_AUTH_TOKEN are required for store=supabase',
+        )
+      }
+      return {
+        type: 'supabase',
+        url: connectionString,
+        key: authToken,
+      }
+    }
+    case 'postgres': {
+      return {
+        type: 'postgres',
+        ...(connectionString !== undefined && { connectionString }),
+      }
+    }
+    default:
+      throw new ConfigError(
+        `FLAKY_TESTS_STORE must be one of sqlite|turso|supabase|postgres, got "${storeType}"`,
+      )
+  }
+}
+
+let cachedConfig: Config | null = null
+let cachedEnv: NodeJS.ProcessEnv | null = null
+
+function isConfigObject(value: unknown): value is Config {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'log' in value &&
+    'store' in value &&
+    'detection' in value
+  )
+}
+
+/**
+ * Build the unified config. Three inputs:
+ *   - no args → read `process.env` (memoized; repeated calls are free)
+ *   - a `NodeJS.ProcessEnv` record → parse that instead (fresh each call)
+ *   - a pre-built `Config` → install it as the cached resolution (useful in tests)
+ */
+export function resolveConfig(
+  source?: NodeJS.ProcessEnv | Config,
+): Config {
+  if (isConfigObject(source)) {
+    cachedConfig = source
+    cachedEnv = process.env
+    return source
+  }
+
+  const env = source ?? process.env
+  if (env === process.env && cachedConfig !== null && cachedEnv === env) {
+    return cachedConfig
+  }
+
+  const raw = {
+    log: { level: resolveLogLevelValue(env.FLAKY_TESTS_LOG) },
+    store: resolveStoreConfig(env),
+    detection: {
+      windowDays: parsePositiveNumber(
+        env.FLAKY_TESTS_WINDOW,
+        DEFAULT_WINDOW_DAYS,
+        'FLAKY_TESTS_WINDOW',
+      ),
+      threshold: parsePositiveInt(
+        env.FLAKY_TESTS_THRESHOLD,
+        DEFAULT_THRESHOLD,
+        'FLAKY_TESTS_THRESHOLD',
+      ),
+    },
+    github: {
+      ...(env.GITHUB_TOKEN !== undefined && { token: env.GITHUB_TOKEN }),
+      ...(env.GITHUB_REPOSITORY !== undefined && {
+        repository: env.GITHUB_REPOSITORY,
+      }),
+    },
+    plugin: {
+      disabled: parseBoolean(env.FLAKY_TESTS_DISABLE),
+      ...(env.FLAKY_TESTS_RUN_ID !== undefined && {
+        runIdOverride: env.FLAKY_TESTS_RUN_ID,
+      }),
+    },
+    report: {
+      ...(env.BROWSER !== undefined && { browser: env.BROWSER }),
+    },
+  }
+
+  let resolved: Config
+  try {
+    resolved = parse(configSchema, raw)
+  } catch (error) {
+    throw new ConfigError(
+      error instanceof Error ? error.message : String(error),
+    )
+  }
+
+  if (env === process.env) {
+    cachedConfig = resolved
+    cachedEnv = env
+  }
+  return resolved
+}
+
+/** Drop the cached resolution so a subsequent `resolveConfig()` re-reads env. */
+export function resetConfigForTesting(): void {
+  cachedConfig = null
+  cachedEnv = null
+}
+
+// ---------------------------------------------------------------------------
+// Test credentials
+// ---------------------------------------------------------------------------
+
+/** Test-only credentials, kept out of `configSchema` because they're harness params, not runtime config. */
+export interface TestCredentials {
+  integration: boolean
+  tursoUrl: string | undefined
+  postgresUrl: string | undefined
+  supabaseUrl: string | undefined
+  supabaseKey: string | undefined
+}
+
+/**
+ * Read integration-test credentials from env. Invoked by integration test
+ * files instead of having each file touch `process.env` directly, so this
+ * module stays the sole env reader.
+ */
+export function getTestCredentials(): TestCredentials {
+  return {
+    integration: parseBoolean(process.env.INTEGRATION),
+    tursoUrl: process.env.TURSO_TEST_URL,
+    postgresUrl: process.env.POSTGRES_TEST_URL,
+    supabaseUrl: process.env.SUPABASE_TEST_URL,
+    supabaseKey: process.env.SUPABASE_TEST_KEY,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Subprocess IPC
+// ---------------------------------------------------------------------------
+
+/**
+ * Publish a generated run id into the current process's env so a spawned
+ * child inherits it and can pick it up via `resolveConfig().plugin.runIdOverride`.
+ * Centralized here so this module remains the sole `process.env` touchpoint.
+ */
+export function publishRunIdForSubprocess(runId: string): void {
+  process.env.FLAKY_TESTS_RUN_ID = runId
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -112,7 +112,9 @@ function parsePositiveInt(
   return parsed
 }
 
-function resolveLogLevelValue(value: string | undefined): Config['log']['level'] {
+function resolveLogLevelValue(
+  value: string | undefined,
+): Config['log']['level'] {
   const lowered = value?.toLowerCase()
   if (
     lowered === 'silent' ||
@@ -125,9 +127,7 @@ function resolveLogLevelValue(value: string | undefined): Config['log']['level']
   return 'warn'
 }
 
-function resolveStoreConfig(
-  env: NodeJS.ProcessEnv,
-): Config['store'] {
+function resolveStoreConfig(env: NodeJS.ProcessEnv): Config['store'] {
   const storeType = env.FLAKY_TESTS_STORE ?? 'sqlite'
   const connectionString = env.FLAKY_TESTS_CONNECTION_STRING
   const authToken = env.FLAKY_TESTS_AUTH_TOKEN
@@ -196,9 +196,7 @@ function isConfigObject(value: unknown): value is Config {
  *   - a `NodeJS.ProcessEnv` record → parse that instead (fresh each call)
  *   - a pre-built `Config` → install it as the cached resolution (useful in tests)
  */
-export function resolveConfig(
-  source?: NodeJS.ProcessEnv | Config,
-): Config {
+export function resolveConfig(source?: NodeJS.ProcessEnv | Config): Config {
   if (isConfigObject(source)) {
     cachedConfig = source
     cachedEnv = process.env

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -15,6 +15,14 @@
  * }
  * ```
  */
+/** Thrown by `resolveConfig()` and `parseCliConfig()` when input validation fails. */
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ConfigError'
+  }
+}
+
 export class StoreError extends Error {
   readonly package: string
   readonly method: string

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,12 +19,6 @@ export {
 } from './defaults'
 export { DescribeStack } from './describe-stack'
 export { ConfigError, StoreError } from './errors'
-export {
-  definePlugin,
-  type FlakyPluginDescriptor,
-  listRegisteredPlugins,
-  resetPluginRegistryForTesting,
-} from './plugin'
 export { captureGitInfo, type RunCommand } from './git'
 export { escapeHtml } from './html-utils'
 export {
@@ -34,6 +28,12 @@ export {
   resolveLogLevel,
 } from './log'
 export { mapRowToPattern, type PatternRow } from './pattern-mapper'
+export {
+  definePlugin,
+  type FlakyPluginDescriptor,
+  listRegisteredPlugins,
+  resetPluginRegistryForTesting,
+} from './plugin'
 export { generatePrompt } from './prompt'
 export {
   failureKindSchema,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,15 @@
 export { categorizeError, extractMessage, extractStack } from './categorize'
 export {
+  type Config,
+  configSchema,
+  getTestCredentials,
+  publishRunIdForSubprocess,
+  resetConfigForTesting,
+  resolveConfig,
+  storeConfigSchema,
+  type TestCredentials,
+} from './config'
+export {
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   MAX_CLI_ERROR_MESSAGE_LENGTH,
@@ -8,7 +18,13 @@ export {
   MS_PER_DAY,
 } from './defaults'
 export { DescribeStack } from './describe-stack'
-export { StoreError } from './errors'
+export { ConfigError, StoreError } from './errors'
+export {
+  definePlugin,
+  type FlakyPluginDescriptor,
+  listRegisteredPlugins,
+  resetPluginRegistryForTesting,
+} from './plugin'
 export { captureGitInfo, type RunCommand } from './git'
 export { escapeHtml } from './html-utils'
 export {

--- a/packages/core/src/log.test.ts
+++ b/packages/core/src/log.test.ts
@@ -1,46 +1,46 @@
 // biome-ignore-all lint/suspicious/noConsole: this is the logger test — it must stub console
 
 import { afterEach, describe, expect, mock, test } from 'bun:test'
-import { createLogger, resolveLogLevel } from './log'
+import { type Config, resetConfigForTesting, resolveConfig } from './config'
+import { createLogger, type LogLevel, resolveLogLevel } from './log'
 
-const originalEnv = process.env.FLAKY_TESTS_LOG
+function baseConfig(level: LogLevel): Config {
+  return {
+    log: { level },
+    store: { type: 'sqlite' },
+    detection: { windowDays: 7, threshold: 2 },
+    github: {},
+    plugin: { disabled: false },
+    report: {},
+  }
+}
+
+function useLevel(level: LogLevel): void {
+  resolveConfig(baseConfig(level))
+}
 
 afterEach(() => {
-  if (originalEnv === undefined) {
-    delete process.env.FLAKY_TESTS_LOG
-  } else {
-    process.env.FLAKY_TESTS_LOG = originalEnv
-  }
+  resetConfigForTesting()
   mock.restore()
 })
 
 describe('resolveLogLevel', () => {
-  test('defaults to warn when env is unset', () => {
-    delete process.env.FLAKY_TESTS_LOG
+  test('defaults to warn when config parsing fails', () => {
+    resetConfigForTesting()
     expect(resolveLogLevel()).toBe('warn')
   })
 
-  test('reads each valid level from env', () => {
+  test('reads each valid level from injected config', () => {
     for (const level of ['silent', 'error', 'warn', 'debug'] as const) {
-      process.env.FLAKY_TESTS_LOG = level
+      useLevel(level)
       expect(resolveLogLevel()).toBe(level)
     }
-  })
-
-  test('is case-insensitive', () => {
-    process.env.FLAKY_TESTS_LOG = 'DEBUG'
-    expect(resolveLogLevel()).toBe('debug')
-  })
-
-  test('falls back to warn on garbage value', () => {
-    process.env.FLAKY_TESTS_LOG = 'loud'
-    expect(resolveLogLevel()).toBe('warn')
   })
 })
 
 describe('createLogger', () => {
   test('prefixes output with [flaky-tests:<namespace>]', () => {
-    process.env.FLAKY_TESTS_LOG = 'debug'
+    useLevel('debug')
     const warnSpy = mock(() => {})
     const originalWarn = console.warn
     console.warn = warnSpy
@@ -56,7 +56,7 @@ describe('createLogger', () => {
   })
 
   test('silent level suppresses every method', () => {
-    process.env.FLAKY_TESTS_LOG = 'silent'
+    useLevel('silent')
     const spies = {
       error: mock(() => {}),
       warn: mock(() => {}),
@@ -86,7 +86,7 @@ describe('createLogger', () => {
   })
 
   test('warn level emits warn+error, suppresses debug', () => {
-    process.env.FLAKY_TESTS_LOG = 'warn'
+    useLevel('warn')
     const spies = {
       error: mock(() => {}),
       warn: mock(() => {}),
@@ -121,9 +121,9 @@ describe('createLogger', () => {
     console.warn = warnSpy
     try {
       const logger = createLogger('ns')
-      process.env.FLAKY_TESTS_LOG = 'silent'
+      useLevel('silent')
       logger.warn('one')
-      process.env.FLAKY_TESTS_LOG = 'warn'
+      useLevel('warn')
       logger.warn('two')
       expect(warnSpy).toHaveBeenCalledTimes(1)
       expect(warnSpy).toHaveBeenCalledWith('[flaky-tests:ns]', 'two')

--- a/packages/core/src/log.ts
+++ b/packages/core/src/log.ts
@@ -6,13 +6,15 @@
  * for their catch-block warn/error calls. CLI user output (pattern summaries,
  * `✓`/`✗` lines) is not logging and continues to use `console.*` directly.
  *
- * Level is resolved from `FLAKY_TESTS_LOG` on every log call so tests can
- * toggle it without re-importing the module. Per the project's convention,
- * logger code is the one place `process.env` may be read directly — it runs
- * before any config parsing.
+ * Level is resolved from `resolveConfig()` on every log call so tests can
+ * toggle it (via `resetConfigForTesting`) without re-importing the module.
+ * If config resolution throws — e.g. the user set an invalid value — the
+ * logger silently falls back to the default level so logging never crashes.
  */
 
 // biome-ignore-all lint/suspicious/noConsole: this is the logger — it owns console.*
+
+import { resolveConfig } from './config'
 
 /** Log severity. Levels are inclusive: `warn` emits warn+error, `debug` emits everything. */
 export type LogLevel = 'silent' | 'error' | 'warn' | 'debug'
@@ -26,18 +28,13 @@ const LEVEL_ORDER: Record<LogLevel, number> = {
 
 const DEFAULT_LEVEL: LogLevel = 'warn'
 
-/** Resolve the active level from env, falling back to the default. */
+/** Resolve the active level from the unified config, falling back if config parsing fails so broken env never silences the logger. */
 export function resolveLogLevel(): LogLevel {
-  const value = process.env.FLAKY_TESTS_LOG?.toLowerCase()
-  if (
-    value === 'silent' ||
-    value === 'error' ||
-    value === 'warn' ||
-    value === 'debug'
-  ) {
-    return value
+  try {
+    return resolveConfig().log.level
+  } catch {
+    return DEFAULT_LEVEL
   }
-  return DEFAULT_LEVEL
 }
 
 export interface Logger {

--- a/packages/core/src/plugin.test.ts
+++ b/packages/core/src/plugin.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import type { Config } from './config'
+import {
+  definePlugin,
+  listRegisteredPlugins,
+  resetPluginRegistryForTesting,
+} from './plugin'
+
+const fakeConfig: Config = {
+  log: { level: 'warn' },
+  store: { type: 'sqlite' },
+  detection: { windowDays: 7, threshold: 2 },
+  github: {},
+  plugin: { disabled: false },
+  report: {},
+}
+
+afterEach(() => {
+  resetPluginRegistryForTesting()
+})
+
+describe('definePlugin', () => {
+  test('registers a descriptor and exposes it via listRegisteredPlugins', () => {
+    const descriptor = definePlugin({
+      name: 'test-plugin',
+      create: () => ({ id: 42 }),
+    })
+    expect(listRegisteredPlugins()).toContain(descriptor)
+  })
+
+  test('rejects duplicate plugin names', () => {
+    definePlugin({ name: 'dup', create: () => 1 })
+    expect(() =>
+      definePlugin({ name: 'dup', create: () => 2 }),
+    ).toThrow(/already registered/)
+  })
+
+  test('re-registering the same descriptor object is idempotent', () => {
+    const descriptor = definePlugin({ name: 'idem', create: () => 'x' })
+    expect(() => definePlugin(descriptor)).not.toThrow()
+  })
+
+  test('create() receives the full config and returns the instance', () => {
+    const descriptor = definePlugin({
+      name: 'echo',
+      create: (config: Config) => ({ windowDays: config.detection.windowDays }),
+    })
+    expect(descriptor.create(fakeConfig)).toEqual({ windowDays: 7 })
+  })
+})

--- a/packages/core/src/plugin.test.ts
+++ b/packages/core/src/plugin.test.ts
@@ -1,10 +1,6 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 import type { Config } from './config'
-import {
-  definePlugin,
-  listRegisteredPlugins,
-  resetPluginRegistryForTesting,
-} from './plugin'
+import { definePlugin, listRegisteredPlugins } from './plugin'
 
 const fakeConfig: Config = {
   log: { level: 'warn' },
@@ -15,34 +11,33 @@ const fakeConfig: Config = {
   report: {},
 }
 
-afterEach(() => {
-  resetPluginRegistryForTesting()
-})
-
+// Unique name prefixes keep these tests from colliding with real plugin
+// descriptors that share the registry. The registry is process-wide module
+// state — wiping it here would clear descriptors other test files rely on.
 describe('definePlugin', () => {
   test('registers a descriptor and exposes it via listRegisteredPlugins', () => {
     const descriptor = definePlugin({
-      name: 'test-plugin',
+      name: 'test:basic-register',
       create: () => ({ id: 42 }),
     })
     expect(listRegisteredPlugins()).toContain(descriptor)
   })
 
   test('rejects duplicate plugin names', () => {
-    definePlugin({ name: 'dup', create: () => 1 })
-    expect(() =>
-      definePlugin({ name: 'dup', create: () => 2 }),
-    ).toThrow(/already registered/)
+    definePlugin({ name: 'test:dup', create: () => 1 })
+    expect(() => definePlugin({ name: 'test:dup', create: () => 2 })).toThrow(
+      /already registered/,
+    )
   })
 
   test('re-registering the same descriptor object is idempotent', () => {
-    const descriptor = definePlugin({ name: 'idem', create: () => 'x' })
+    const descriptor = definePlugin({ name: 'test:idem', create: () => 'x' })
     expect(() => definePlugin(descriptor)).not.toThrow()
   })
 
   test('create() receives the full config and returns the instance', () => {
     const descriptor = definePlugin({
-      name: 'echo',
+      name: 'test:echo',
       create: (config: Config) => ({ windowDays: config.detection.windowDays }),
     })
     expect(descriptor.create(fakeConfig)).toEqual({ windowDays: 7 })

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -1,0 +1,47 @@
+/**
+ * Plugin contract shared by stores and test-runner plugins.
+ *
+ * A plugin descriptor is a lazy factory: `create(config)` constructs the
+ * real instance on demand. Importing a plugin module registers its
+ * descriptor without performing any I/O — DB handles and Bun preload
+ * wiring only happen when `create()` is called.
+ */
+
+import type { Type } from 'arktype'
+import type { Config } from './config'
+
+export interface FlakyPluginDescriptor<Instance = unknown> {
+  readonly name: string
+  readonly configSchema?: Type
+  create(config: Config): Instance
+}
+
+const registry = new Map<string, FlakyPluginDescriptor>()
+
+/**
+ * Register a plugin descriptor. Throws if a plugin with the same name is
+ * already registered — silent overwrites would make the registry a
+ * last-import-wins lottery.
+ */
+export function definePlugin<Instance>(
+  descriptor: FlakyPluginDescriptor<Instance>,
+): FlakyPluginDescriptor<Instance> {
+  const existing = registry.get(descriptor.name)
+  if (existing !== undefined && existing !== descriptor) {
+    throw new Error(
+      `flaky-tests: plugin "${descriptor.name}" is already registered`,
+    )
+  }
+  registry.set(descriptor.name, descriptor as FlakyPluginDescriptor)
+  return descriptor
+}
+
+/** Read-only snapshot of every registered plugin descriptor. */
+export function listRegisteredPlugins(): ReadonlyArray<FlakyPluginDescriptor> {
+  return Array.from(registry.values())
+}
+
+/** Drop every registration — test-only escape hatch. */
+export function resetPluginRegistryForTesting(): void {
+  registry.clear()
+}

--- a/packages/plugin-bun/src/index.ts
+++ b/packages/plugin-bun/src/index.ts
@@ -1,3 +1,14 @@
+import { type Config, definePlugin } from '@flaky-tests/core'
+import { createPreload } from './preload'
+
 export type { GitInfo } from './git'
 export { captureGitInfo } from './git'
 export { createPreload } from './preload'
+
+/** Lazy plugin descriptor — `create(config)` returns the Bun preload wiring helper. */
+export const bunPlugin = definePlugin({
+  name: 'plugin-bun',
+  create(_config: Config) {
+    return { createPreload }
+  },
+})

--- a/packages/plugin-bun/src/preload-sqlite.ts
+++ b/packages/plugin-bun/src/preload-sqlite.ts
@@ -6,22 +6,19 @@
  *   [test]
  *   preload = ["@flaky-tests/plugin-bun/preload"]
  *
- * Environment variables:
- *   FLAKY_TESTS_DISABLE=1   — skip all telemetry
- *   FLAKY_TESTS_DB=<path>   — override DB path
- *   FLAKY_TESTS_RUN_ID=<id> — set by run-tracked for reconciliation
+ * Configuration flows through `resolveConfig()` — see core/src/config.ts.
  */
 
 // biome-ignore-all lint/suspicious/noConsole: preload is dev tooling
 
-import { SqliteStore } from '@flaky-tests/store-sqlite'
+import { resolveConfig } from '@flaky-tests/core'
+import { sqliteStorePlugin } from '@flaky-tests/store-sqlite'
 import { createPreload } from './preload'
 
-if (process.env.FLAKY_TESTS_DISABLE !== '1') {
+const config = resolveConfig()
+if (!config.plugin.disabled) {
   try {
-    const store = new SqliteStore({
-      dbPath: process.env.FLAKY_TESTS_DB ?? undefined,
-    })
+    const store = sqliteStorePlugin.create(config)
     createPreload(store)
   } catch (error) {
     console.warn('[flaky-tests] Failed to initialise preload:', error)

--- a/packages/plugin-bun/src/preload.ts
+++ b/packages/plugin-bun/src/preload.ts
@@ -31,6 +31,7 @@ import {
   insertFailureInputSchema,
   insertRunInputSchema,
   parse,
+  resolveConfig,
   updateRunInputSchema,
 } from '@flaky-tests/core'
 import { captureGitInfo } from './git'
@@ -97,8 +98,8 @@ export function createPreload(store: IStore): void {
   installed = true
 
   // Use a run id provided by run-tracked (so it can reconcile the row post-exit)
-  // or generate a fresh one. Reject garbage from env.
-  const providedRunId = process.env.FLAKY_TESTS_RUN_ID
+  // or generate a fresh one. Reject garbage from the config override.
+  const providedRunId = resolveConfig().plugin.runIdOverride
   const runIdFromEnv =
     providedRunId !== undefined && RUN_ID_PATTERN.test(providedRunId)
   const runId = runIdFromEnv ? providedRunId : crypto.randomUUID()

--- a/packages/plugin-bun/src/run-tracked.ts
+++ b/packages/plugin-bun/src/run-tracked.ts
@@ -15,19 +15,27 @@
 
 // biome-ignore-all lint/suspicious/noConsole: CLI wrapper
 
+import { publishRunIdForSubprocess, resolveConfig } from '@flaky-tests/core'
 import { SqliteStore } from '@flaky-tests/store-sqlite'
 
+const config = resolveConfig()
 const DB_PATH =
-  process.env.FLAKY_TESTS_DB ?? 'node_modules/.cache/flaky-tests/failures.db'
+  config.store.type === 'sqlite' && config.store.path !== undefined
+    ? config.store.path
+    : 'node_modules/.cache/flaky-tests/failures.db'
 
 /** Spawns `bun test` as a child so the authoritative exit code survives module-load errors the preload cannot observe in-process. */
 async function main(): Promise<number> {
   const runId = crypto.randomUUID()
   const forwardedArgs = process.argv.slice(2)
 
+  // Publish the generated run id so the child's preload picks it up via
+  // `resolveConfig().plugin.runIdOverride`. Bun.spawn inherits process.env
+  // when `env` is omitted; the helper lives in core so env access stays in
+  // one module.
+  publishRunIdForSubprocess(runId)
   const child = Bun.spawn({
     cmd: ['bun', 'test', ...forwardedArgs],
-    env: { ...process.env, FLAKY_TESTS_RUN_ID: runId },
     stdout: 'inherit',
     stderr: 'inherit',
     stdin: 'inherit',

--- a/packages/plugin-vitest/src/index.ts
+++ b/packages/plugin-vitest/src/index.ts
@@ -19,11 +19,17 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import type { InsertFailureInput, IStore, RunCommand } from '@flaky-tests/core'
+import type {
+  Config,
+  InsertFailureInput,
+  IStore,
+  RunCommand,
+} from '@flaky-tests/core'
 import {
   captureGitInfo as captureGitInfoCore,
   categorizeError,
   createLogger,
+  definePlugin,
   extractMessage,
   extractStack,
   insertFailureInputSchema,
@@ -223,3 +229,11 @@ export class FlakyTestsReporter {
     await this.store.close().catch((e: unknown) => log.warn('close failed:', e))
   }
 }
+
+/** Lazy plugin descriptor — `create(config)` exposes the FlakyTestsReporter constructor so hosts can wire it into Vitest with any IStore. */
+export const vitestPlugin = definePlugin({
+  name: 'plugin-vitest',
+  create(_config: Config) {
+    return { FlakyTestsReporter }
+  },
+})

--- a/packages/store-postgres/src/index.integration.test.ts
+++ b/packages/store-postgres/src/index.integration.test.ts
@@ -10,11 +10,12 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
-import type { FailureKind } from '@flaky-tests/core'
+import { type FailureKind, getTestCredentials } from '@flaky-tests/core'
 import { PostgresStore } from './index'
 
-const SKIP = !process.env.INTEGRATION || !process.env.POSTGRES_TEST_URL
-const CONNECTION_STRING = process.env.POSTGRES_TEST_URL ?? ''
+const credentials = getTestCredentials()
+const SKIP = !credentials.integration || !credentials.postgresUrl
+const CONNECTION_STRING = credentials.postgresUrl ?? ''
 
 // Use a unique prefix per run to avoid collisions
 const PREFIX = `ft_test_${Date.now()}`

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -1,9 +1,9 @@
 import {
   type Config,
   createLogger,
-  definePlugin,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
+  definePlugin,
   type FlakyPattern,
   flakyPatternSchema,
   type GetNewPatternsOptions,

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -1,5 +1,7 @@
 import {
+  type Config,
   createLogger,
+  definePlugin,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   type FlakyPattern,
@@ -261,3 +263,18 @@ export class PostgresStore implements IStore {
     await this.sql.end()
   }
 }
+
+/** Lazy plugin descriptor — `create(config)` builds a PostgresStore from the resolved config. */
+export const postgresStorePlugin = definePlugin({
+  name: 'store-postgres',
+  configSchema: postgresStoreOptionsSchema,
+  create(config: Config): PostgresStore {
+    if (config.store.type !== 'postgres') {
+      throw new Error(
+        `store-postgres plugin invoked with config.store.type="${config.store.type}"`,
+      )
+    }
+    const { type: _type, ...storeOptions } = config.store
+    return new PostgresStore(storeOptions)
+  },
+})

--- a/packages/store-sqlite/src/index.ts
+++ b/packages/store-sqlite/src/index.ts
@@ -1,9 +1,11 @@
 import { Database } from 'bun:sqlite'
 import { mkdirSync } from 'node:fs'
 import {
+  type Config,
   createLogger,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
+  definePlugin,
   type FlakyPattern,
   flakyPatternSchema,
   type GetNewPatternsOptions,
@@ -334,3 +336,19 @@ export class SqliteStore implements IStore {
     return this.db
   }
 }
+
+/** Lazy plugin descriptor — `create(config)` builds a SqliteStore from the resolved config. */
+export const sqliteStorePlugin = definePlugin({
+  name: 'store-sqlite',
+  configSchema: sqliteStoreOptionsSchema,
+  create(config: Config): SqliteStore {
+    if (config.store.type !== 'sqlite') {
+      throw new Error(
+        `store-sqlite plugin invoked with config.store.type="${config.store.type}"`,
+      )
+    }
+    return new SqliteStore({
+      ...(config.store.path !== undefined && { dbPath: config.store.path }),
+    })
+  },
+})

--- a/packages/store-sqlite/src/report.ts
+++ b/packages/store-sqlite/src/report.ts
@@ -18,11 +18,15 @@ import {
   type FlakyPattern,
   generatePrompt,
   MAX_FAILED_TESTS_PER_RUN,
+  resolveConfig,
   stripTimestampPrefix,
 } from '@flaky-tests/core'
 
+const reportConfig = resolveConfig()
 const DB_PATH =
-  process.env.FLAKY_TESTS_DB ?? 'node_modules/.cache/flaky-tests/failures.db'
+  reportConfig.store.type === 'sqlite' && reportConfig.store.path !== undefined
+    ? reportConfig.store.path
+    : 'node_modules/.cache/flaky-tests/failures.db'
 const DEFAULT_OUT_PATH = 'test-report.html'
 const outFlagIndex = process.argv.indexOf('--out')
 const OUT_PATH =
@@ -631,7 +635,7 @@ function render(data: ReturnType<typeof loadData>): string {
 function openInBrowser(filePath: string): void {
   const abs = Bun.fileURLToPath(new URL(filePath, `file://${process.cwd()}/`))
   const url = `file://${abs}`
-  const envBrowser = process.env.BROWSER
+  const envBrowser = reportConfig.report.browser
   let cmd: string[]
   if (envBrowser) cmd = [envBrowser, url]
   else if (process.platform === 'darwin') cmd = ['open', url]

--- a/packages/store-supabase/src/index.integration.test.ts
+++ b/packages/store-supabase/src/index.integration.test.ts
@@ -25,14 +25,16 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { getTestCredentials } from '@flaky-tests/core'
 import { SupabaseStore } from './index'
 
+const credentials = getTestCredentials()
 const SKIP =
-  !process.env.INTEGRATION ||
-  !process.env.SUPABASE_TEST_URL ||
-  !process.env.SUPABASE_TEST_KEY
-const SUPABASE_URL = process.env.SUPABASE_TEST_URL ?? ''
-const SUPABASE_KEY = process.env.SUPABASE_TEST_KEY ?? ''
+  !credentials.integration ||
+  !credentials.supabaseUrl ||
+  !credentials.supabaseKey
+const SUPABASE_URL = credentials.supabaseUrl ?? ''
+const SUPABASE_KEY = credentials.supabaseKey ?? ''
 const TABLE_PREFIX = 'ft_integ'
 
 // ---------------------------------------------------------------------------

--- a/packages/store-supabase/src/index.ts
+++ b/packages/store-supabase/src/index.ts
@@ -1,9 +1,9 @@
 import {
   type Config,
   createLogger,
-  definePlugin,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
+  definePlugin,
   type FlakyPattern,
   flakyPatternSchema,
   type GetNewPatternsOptions,

--- a/packages/store-supabase/src/index.ts
+++ b/packages/store-supabase/src/index.ts
@@ -1,5 +1,7 @@
 import {
+  type Config,
   createLogger,
+  definePlugin,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   type FlakyPattern,
@@ -297,3 +299,23 @@ export class SupabaseStore implements IStore {
     // Supabase JS client has no explicit close; connections are managed internally.
   }
 }
+
+/** Lazy plugin descriptor — `create(config)` builds a SupabaseStore from the resolved config. */
+export const supabaseStorePlugin = definePlugin({
+  name: 'store-supabase',
+  configSchema: supabaseStoreOptionsSchema,
+  create(config: Config): SupabaseStore {
+    if (config.store.type !== 'supabase') {
+      throw new Error(
+        `store-supabase plugin invoked with config.store.type="${config.store.type}"`,
+      )
+    }
+    return new SupabaseStore({
+      url: config.store.url,
+      key: config.store.key,
+      ...(config.store.tablePrefix !== undefined && {
+        tablePrefix: config.store.tablePrefix,
+      }),
+    })
+  },
+})

--- a/packages/store-turso/src/index.integration.test.ts
+++ b/packages/store-turso/src/index.integration.test.ts
@@ -7,11 +7,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import type { FailureKind } from '@flaky-tests/core'
+import { type FailureKind, getTestCredentials } from '@flaky-tests/core'
 import { TursoStore } from './index'
 
-const SKIP = !process.env.INTEGRATION
-const TURSO_URL = process.env.TURSO_TEST_URL ?? 'file::memory:'
+const credentials = getTestCredentials()
+const SKIP = !credentials.integration
+const TURSO_URL = credentials.tursoUrl ?? 'file::memory:'
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/store-turso/src/index.ts
+++ b/packages/store-turso/src/index.ts
@@ -1,9 +1,9 @@
 import {
   type Config,
   createLogger,
-  definePlugin,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
+  definePlugin,
   type FlakyPattern,
   flakyPatternSchema,
   type GetNewPatternsOptions,

--- a/packages/store-turso/src/index.ts
+++ b/packages/store-turso/src/index.ts
@@ -1,5 +1,7 @@
 import {
+  type Config,
   createLogger,
+  definePlugin,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   type FlakyPattern,
@@ -271,3 +273,22 @@ export class TursoStore implements IStore {
     this.client.close()
   }
 }
+
+/** Lazy plugin descriptor — `create(config)` builds a TursoStore from the resolved config. */
+export const tursoStorePlugin = definePlugin({
+  name: 'store-turso',
+  configSchema: tursoStoreOptionsSchema,
+  create(config: Config): TursoStore {
+    if (config.store.type !== 'turso') {
+      throw new Error(
+        `store-turso plugin invoked with config.store.type="${config.store.type}"`,
+      )
+    }
+    return new TursoStore({
+      url: config.store.url,
+      ...(config.store.authToken !== undefined && {
+        authToken: config.store.authToken,
+      }),
+    })
+  },
+})


### PR DESCRIPTION
Closes #24.

## Summary
- Centralize every `process.env` touchpoint in `packages/core/src/config.ts`. Every other call site consumes a typed `Config` via `resolveConfig()`.
- Introduce a `FlakyPluginDescriptor` / `definePlugin` / `listRegisteredPlugins` contract with **lazy** registration — importing a store package opens no DB handle.
- Each store is a class that implements `IStore`; each store and runner plugin exports a descriptor wired via `definePlugin`. Existing `create*Store()` factories are preserved.

## Key design decisions
- **Lazy descriptor**, not eager instance. `definePlugin({ name, configSchema, create(config) })`. Stores open nothing at import.
- **Discriminated union on `store.type`** in `configSchema` — each variant carries only its own fields; matches the per-store `OptionsSchema` already in each package.
- **`BROWSER` and `FLAKY_TESTS_RUN_ID` folded into Config** (`report.browser`, `plugin.runIdOverride`).
- `resolveConfig` overloaded: no-args (reads `process.env`, memoized), env record, or a pre-built `Config` (installs it as the cached resolution — lets tests inject without touching env).
- `ConfigError` relocated from `cli` to `core` (re-exported from cli). `resolveLogLevel` now reads from `resolveConfig()` with graceful fallback so a broken env never silences the logger.
- Integration tests call `getTestCredentials()` instead of reading `INTEGRATION` / `*_TEST_URL` / `*_TEST_KEY` directly.
- `publishRunIdForSubprocess(runId)` in `config.ts` owns the one env *write* (run-tracked IPC). `run-tracked.ts` calls the helper; no direct `process.env` touches.

## Files touched
- **Core**: new `config.ts`, `plugin.ts`, `config.test.ts`, `plugin.test.ts`; `errors.ts` gains `ConfigError`; `index.ts` exports; `log.ts` reads via config.
- **CLI**: `args.ts` drops `env` param, takes `defaults` from Config; `check.ts` resolveStore consumes Config; `github.ts` resolveRepo consumes Config; `errors.ts` re-exports core `ConfigError`; `plugin-registry.test.ts` enforces registry completeness.
- **plugin-bun**: descriptor in `index.ts`; `preload-sqlite`/`preload`/`run-tracked` go through `resolveConfig`.
- **plugin-vitest**: descriptor.
- **stores** (sqlite/turso/supabase/postgres): descriptors; `sqlite/report.ts` consumes Config.

## Verification
- [x] `bun test` — 244 pass / 0 fail
- [x] `bun run build` — all packages build
- [x] `rg 'process.env' packages/*/src` — every runtime read/write is in `packages/core/src/config.ts` (one doc comment in `run-tracked.ts` is the only other hit)
- [x] CLI smoke: `FLAKY_TESTS_THRESHOLD=abc bun packages/cli/src/check.ts` exits 2 with a clean message
- [x] Registry completeness test imports every plugin and store entrypoint and asserts each `name` appears in `listRegisteredPlugins()`

## Out of scope (per the issue)
- `.flaky-testsrc` config file loader
- Renaming any env vars
- Plugin lifecycle beyond `IStore.close`

🤖 Generated with [Claude Code](https://claude.com/claude-code)