### PR TITLE
feat(core): shared IStore contract test suite

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -80,7 +80,11 @@
   },
   "overrides": [
     {
-      "includes": ["**/*.test.ts", "**/*.integration.test.ts"],
+      "includes": [
+        "**/*.test.ts",
+        "**/*.integration.test.ts",
+        "packages/core/src/test-helpers/**"
+      ],
       "linter": {
         "rules": {
           "style": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,11 @@
       "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./test-helpers": {
+      "bun": "./src/test-helpers/index.ts",
+      "import": "./dist/test-helpers/index.js",
+      "types": "./dist/test-helpers/index.d.ts"
     }
   },
   "main": "./dist/index.js",
@@ -17,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir dist --format esm --target node",
+    "build": "bun build ./src/index.ts ./src/test-helpers/index.ts --outdir dist --format esm --target node --external bun:test",
     "build:types": "tsc --project tsconfig.build.json",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",

--- a/packages/core/src/test-helpers/contract.ts
+++ b/packages/core/src/test-helpers/contract.ts
@@ -1,0 +1,296 @@
+/**
+ * Shared IStore contract suite. Every adapter (sqlite/turso/postgres/supabase)
+ * invokes `runContractTests(label, makeStore)` so IStore semantics stay locked
+ * in: adapter divergence shows up as a test failure at the exact scenario that
+ * differs, not as a production regression weeks later.
+ *
+ * Each test builds a fresh store via the supplied factory and uses unique
+ * runIds via `crypto.randomUUID()` so adapters that share a table (postgres,
+ * supabase) do not suffer cross-test pollution.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { MAX_FAILED_TESTS_PER_RUN } from '../defaults'
+import type { IStore } from '../types'
+import { ValidationError } from '../validate-schemas'
+import { daysAgo, makeFailure, makeRun } from './fixtures'
+
+/**
+ * Invoke the shared contract suite. `makeStore` is called once per test so
+ * every scenario starts with fresh store state (for in-memory adapters) or a
+ * fresh client (for remote adapters — isolation is then provided by unique
+ * runIds generated inside each test).
+ */
+export function runContractTests(
+  label: string,
+  makeStore: () => IStore | Promise<IStore>,
+): void {
+  describe(`IStore contract: ${label}`, () => {
+    let store: IStore
+
+    beforeEach(async () => {
+      store = await makeStore()
+      await store.migrate()
+    })
+
+    afterEach(async () => {
+      await store.close()
+    })
+
+    /** Seed a completed run with the given failures, all under a unique runId. */
+    async function seedRun(
+      failures: Array<{
+        name: string
+        daysBack: number
+        kind?: 'assertion' | 'timeout' | 'uncaught' | 'unknown'
+      }>,
+      overrides: { failedTests?: number; runId?: string } = {},
+    ): Promise<string> {
+      const runId = overrides.runId ?? crypto.randomUUID()
+      const startedAt = daysAgo(failures[0]?.daysBack ?? 0)
+      await store.insertRun(makeRun(runId, startedAt))
+      await store.updateRun(runId, {
+        endedAt: new Date().toISOString(),
+        status: 'fail',
+        totalTests: failures.length + 5,
+        passedTests: 5,
+        failedTests: overrides.failedTests ?? failures.length,
+      })
+      for (const failure of failures) {
+        await store.insertFailure(
+          makeFailure(
+            runId,
+            failure.name,
+            daysAgo(failure.daysBack),
+            failure.kind ?? 'assertion',
+          ),
+        )
+      }
+      return runId
+    }
+
+    // --- Round-trip + validation -------------------------------------------
+
+    test('insertRun → insertFailure → getNewPatterns reflects the failure', async () => {
+      const testName = `t-${crypto.randomUUID()}`
+      await seedRun([
+        { name: testName, daysBack: 1 },
+        { name: testName, daysBack: 2 },
+      ])
+      const patterns = await store.getNewPatterns({
+        windowDays: 7,
+        threshold: 2,
+      })
+      const match = patterns.find((pattern) => pattern.testName === testName)
+      expect(match).toBeDefined()
+      expect(match?.recentFails).toBe(2)
+      expect(match?.priorFails).toBe(0)
+    })
+
+    test('getNewPatterns only counts runs with ended_at set (updateRun finalizes)', async () => {
+      const runId = crypto.randomUUID()
+      const testName = `t-${crypto.randomUUID()}`
+      await store.insertRun(makeRun(runId, daysAgo(1)))
+      // NOTE: no updateRun — the run is not finalized.
+      await store.insertFailure(makeFailure(runId, testName, daysAgo(1)))
+      await store.insertFailure(makeFailure(runId, testName, daysAgo(1)))
+      const patterns = await store.getNewPatterns({
+        windowDays: 7,
+        threshold: 2,
+      })
+      expect(
+        patterns.find((pattern) => pattern.testName === testName),
+      ).toBeUndefined()
+    })
+
+    test('insertFailures batch writes all rows', async () => {
+      const runId = crypto.randomUUID()
+      const testName = `t-${crypto.randomUUID()}`
+      await store.insertRun(makeRun(runId, daysAgo(1)))
+      await store.updateRun(runId, {
+        endedAt: new Date().toISOString(),
+        status: 'fail',
+        totalTests: 3,
+        passedTests: 1,
+        failedTests: 2,
+      })
+      await store.insertFailures([
+        makeFailure(runId, testName, daysAgo(1)),
+        makeFailure(runId, testName, daysAgo(2)),
+      ])
+      const patterns = await store.getNewPatterns({
+        windowDays: 7,
+        threshold: 2,
+      })
+      expect(
+        patterns.find((pattern) => pattern.testName === testName)?.recentFails,
+      ).toBe(2)
+    })
+
+    test('validation rejects malformed input before touching the DB', async () => {
+      await expect(
+        store.insertRun({
+          runId: '',
+          startedAt: 'not-an-iso-timestamp',
+        }),
+      ).rejects.toBeInstanceOf(ValidationError)
+    })
+
+    // --- getNewPatterns pattern detection ----------------------------------
+
+    test('no prior failures + above threshold → flagged', async () => {
+      const testName = `t-${crypto.randomUUID()}`
+      await seedRun([
+        { name: testName, daysBack: 1 },
+        { name: testName, daysBack: 2 },
+      ])
+      const pattern = (
+        await store.getNewPatterns({ windowDays: 7, threshold: 2 })
+      ).find((p) => p.testName === testName)
+      expect(pattern).toBeDefined()
+      expect(pattern?.recentFails).toBe(2)
+      expect(pattern?.priorFails).toBe(0)
+    })
+
+    test('prior failures + recent failures → NOT flagged (not newly flaky)', async () => {
+      const testName = `t-${crypto.randomUUID()}`
+      await seedRun([
+        { name: testName, daysBack: 1 },
+        { name: testName, daysBack: 2 },
+        { name: testName, daysBack: 10 }, // prior window
+      ])
+      const pattern = (
+        await store.getNewPatterns({ windowDays: 7, threshold: 2 })
+      ).find((p) => p.testName === testName)
+      expect(pattern).toBeUndefined()
+    })
+
+    test('recent failures below threshold → not flagged', async () => {
+      const testName = `t-${crypto.randomUUID()}`
+      await seedRun([{ name: testName, daysBack: 1 }])
+      const pattern = (
+        await store.getNewPatterns({ windowDays: 7, threshold: 2 })
+      ).find((p) => p.testName === testName)
+      expect(pattern).toBeUndefined()
+    })
+
+    test('only prior failures → not flagged', async () => {
+      const testName = `t-${crypto.randomUUID()}`
+      await seedRun([
+        { name: testName, daysBack: 10 },
+        { name: testName, daysBack: 11 },
+      ])
+      const pattern = (
+        await store.getNewPatterns({ windowDays: 7, threshold: 2 })
+      ).find((p) => p.testName === testName)
+      expect(pattern).toBeUndefined()
+    })
+
+    test('window edge: failures just inside windowDays count, just outside do not', async () => {
+      const insideName = `inside-${crypto.randomUUID()}`
+      const outsideName = `outside-${crypto.randomUUID()}`
+      await seedRun([
+        { name: insideName, daysBack: 6 },
+        { name: insideName, daysBack: 5 },
+        { name: outsideName, daysBack: 8 }, // outside 7-day window
+        { name: outsideName, daysBack: 9 },
+      ])
+      const patterns = await store.getNewPatterns({
+        windowDays: 7,
+        threshold: 2,
+      })
+      expect(patterns.find((p) => p.testName === insideName)).toBeDefined()
+      expect(patterns.find((p) => p.testName === outsideName)).toBeUndefined()
+    })
+
+    test('custom threshold overrides the default', async () => {
+      const testName = `t-${crypto.randomUUID()}`
+      await seedRun([
+        { name: testName, daysBack: 1 },
+        { name: testName, daysBack: 2 },
+      ])
+      const belowCustom = await store.getNewPatterns({ threshold: 3 })
+      const atCustom = await store.getNewPatterns({ threshold: 2 })
+      expect(belowCustom.find((p) => p.testName === testName)).toBeUndefined()
+      expect(atCustom.find((p) => p.testName === testName)).toBeDefined()
+    })
+
+    test('multiple patterns sorted by recentFails descending', async () => {
+      const heavy = `heavy-${crypto.randomUUID()}`
+      const light = `light-${crypto.randomUUID()}`
+      await seedRun([
+        { name: heavy, daysBack: 1 },
+        { name: heavy, daysBack: 2 },
+        { name: heavy, daysBack: 3 },
+        { name: light, daysBack: 1 },
+        { name: light, daysBack: 2 },
+      ])
+      const patterns = (
+        await store.getNewPatterns({ windowDays: 7, threshold: 2 })
+      ).filter((p) => p.testName === heavy || p.testName === light)
+      expect(patterns.map((p) => p.testName)).toEqual([heavy, light])
+      expect(patterns[0]?.recentFails).toBe(3)
+      expect(patterns[1]?.recentFails).toBe(2)
+    })
+
+    test('collects distinct failure kinds per test', async () => {
+      const testName = `t-${crypto.randomUUID()}`
+      await seedRun([
+        { name: testName, daysBack: 1, kind: 'assertion' },
+        { name: testName, daysBack: 2, kind: 'timeout' },
+      ])
+      const pattern = (
+        await store.getNewPatterns({ windowDays: 7, threshold: 2 })
+      ).find((p) => p.testName === testName)
+      expect(pattern?.failureKinds.slice().sort()).toEqual([
+        'assertion',
+        'timeout',
+      ])
+    })
+
+    test('lastErrorMessage reflects the most recent failure in the current window', async () => {
+      const runId = crypto.randomUUID()
+      const testName = `t-${crypto.randomUUID()}`
+      await store.insertRun(makeRun(runId, daysAgo(2)))
+      await store.updateRun(runId, {
+        endedAt: new Date().toISOString(),
+        status: 'fail',
+        totalTests: 2,
+        passedTests: 0,
+        failedTests: 2,
+      })
+      await store.insertFailure({
+        ...makeFailure(runId, testName, daysAgo(2)),
+        errorMessage: 'older error',
+      })
+      await store.insertFailure({
+        ...makeFailure(runId, testName, daysAgo(1)),
+        errorMessage: 'newer error',
+      })
+      const pattern = (
+        await store.getNewPatterns({ windowDays: 7, threshold: 2 })
+      ).find((p) => p.testName === testName)
+      expect(pattern?.lastErrorMessage).toBe('newer error')
+    })
+
+    test('excludes runs with failed_tests >= MAX_FAILED_TESTS_PER_RUN (infra blowup filter)', async () => {
+      const testName = `t-${crypto.randomUUID()}`
+      await seedRun(
+        [
+          { name: testName, daysBack: 1 },
+          { name: testName, daysBack: 2 },
+        ],
+        { failedTests: MAX_FAILED_TESTS_PER_RUN },
+      )
+      const pattern = (
+        await store.getNewPatterns({ windowDays: 7, threshold: 2 })
+      ).find((p) => p.testName === testName)
+      expect(pattern).toBeUndefined()
+    })
+
+    test('close() is idempotent — a second call does not throw', async () => {
+      await store.close()
+      await expect(store.close()).resolves.toBeUndefined()
+    })
+  })
+}

--- a/packages/core/src/test-helpers/fixtures.ts
+++ b/packages/core/src/test-helpers/fixtures.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared fixture builders for store adapter tests. Keep these identical
+ * across every adapter so the contract suite exercises the same shape
+ * everywhere — that's the whole point of centralizing them.
+ */
+
+import type { FailureKind, InsertFailureInput, InsertRunInput } from '../types'
+
+const MS_PER_DAY = 86_400_000
+
+/** Return a `Date` `n` days before now. Used by contract tests to place
+ *  failures inside or outside the recent window. */
+export function daysAgo(n: number): Date {
+  return new Date(Date.now() - n * MS_PER_DAY)
+}
+
+/** Minimal valid `InsertRunInput`: just a runId and a startedAt timestamp. */
+export function makeRun(
+  runId: string,
+  startedAt: Date = new Date(),
+): InsertRunInput {
+  return {
+    runId,
+    startedAt: startedAt.toISOString(),
+  }
+}
+
+/** Minimal valid `InsertFailureInput` for a single test failure. */
+export function makeFailure(
+  runId: string,
+  testName: string,
+  failedAt: Date,
+  kind: FailureKind = 'assertion',
+): InsertFailureInput {
+  return {
+    runId,
+    testFile: 'tests/example.test.ts',
+    testName,
+    failureKind: kind,
+    errorMessage: `${testName} failed`,
+    errorStack: null,
+    failedAt: failedAt.toISOString(),
+  }
+}

--- a/packages/core/src/test-helpers/index.ts
+++ b/packages/core/src/test-helpers/index.ts
@@ -1,0 +1,2 @@
+export { runContractTests } from './contract'
+export { daysAgo, makeFailure, makeRun } from './fixtures'

--- a/packages/store-postgres/src/index.integration.test.ts
+++ b/packages/store-postgres/src/index.integration.test.ts
@@ -10,7 +10,12 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
-import { type FailureKind, getTestCredentials } from '@flaky-tests/core'
+import { getTestCredentials } from '@flaky-tests/core'
+import {
+  daysAgo,
+  makeFailure,
+  runContractTests,
+} from '@flaky-tests/core/test-helpers'
 import { PostgresStore } from './index'
 
 const credentials = getTestCredentials()
@@ -20,29 +25,17 @@ const CONNECTION_STRING = credentials.postgresUrl ?? ''
 // Use a unique prefix per run to avoid collisions
 const PREFIX = `ft_test_${Date.now()}`
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function daysAgo(n: number): Date {
-  return new Date(Date.now() - n * 86400000)
-}
-
-function makeFailure(
-  runId: string,
-  testName: string,
-  failedAt: Date,
-  kind: FailureKind = 'assertion',
-) {
-  return {
-    runId,
-    testFile: 'tests/example.test.ts',
-    testName,
-    failureKind: kind,
-    errorMessage: `${testName} failed`,
-    errorStack: null,
-    failedAt: failedAt.toISOString(),
-  }
+// Shared IStore contract — each test builds a fresh store against the same
+// prefixed schema; isolation is provided by per-test runIds inside the suite.
+if (!SKIP) {
+  runContractTests(
+    'postgres',
+    () =>
+      new PostgresStore({
+        connectionString: CONNECTION_STRING,
+        tablePrefix: PREFIX,
+      }),
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-sqlite/src/index.test.ts
+++ b/packages/store-sqlite/src/index.test.ts
@@ -1,38 +1,19 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import type { FailureKind } from '@flaky-tests/core'
+import {
+  daysAgo,
+  makeFailure,
+  makeRun,
+  runContractTests,
+} from '@flaky-tests/core/test-helpers'
 import { SqliteStore } from './index'
 
-// Helpers ----------------------------------------------------------------
+// Shared IStore contract — every adapter runs the same scenarios.
+runContractTests('sqlite', () => new SqliteStore({ dbPath: ':memory:' }))
 
-function makeRun(runId: string, _failedTests = 1) {
-  return {
-    runId,
-    startedAt: new Date().toISOString(),
-  }
-}
+// --- SqliteStore-specific supplements -----------------------------------
+// These cover behaviour not in the IStore contract: reconcileRun,
+// getDb, and duplicate-insertRun PK violation semantics.
 
-function makeFailure(
-  runId: string,
-  testName: string,
-  failedAt: Date,
-  kind: FailureKind = 'assertion',
-) {
-  return {
-    runId,
-    testFile: 'tests/example.test.ts',
-    testName,
-    failureKind: kind,
-    errorMessage: `${testName} failed`,
-    errorStack: null,
-    failedAt: failedAt.toISOString(),
-  }
-}
-
-function daysAgo(n: number): Date {
-  return new Date(Date.now() - n * 86400000)
-}
-
-// Each test gets a fresh in-memory database
 let store: SqliteStore
 
 beforeEach(() => {
@@ -43,184 +24,10 @@ afterEach(async () => {
   await store.close()
 })
 
-// Tests ------------------------------------------------------------------
-
-describe('SqliteStore — basic operations', () => {
-  test('inserts and closes without error', async () => {
-    await store.insertRun(makeRun('run-1'))
-    await store.updateRun('run-1', {
-      endedAt: new Date().toISOString(),
-      status: 'fail',
-      totalTests: 10,
-      passedTests: 9,
-      failedTests: 1,
-    })
-    await store.insertFailure(makeFailure('run-1', 'auth > login', new Date()))
-  })
-
-  test('insertRun is idempotent for the same runId — second insert throws', async () => {
+describe('SqliteStore — adapter-specific', () => {
+  test('insertRun with a duplicate runId throws', async () => {
     await store.insertRun(makeRun('run-dup'))
     expect(() => store.insertRun(makeRun('run-dup'))).toThrow()
-  })
-})
-
-describe('SqliteStore — getNewPatterns', () => {
-  async function seedRun(
-    runId: string,
-    failures: Array<{
-      name: string
-      daysBack: number
-      kind?: 'assertion' | 'timeout' | 'uncaught' | 'unknown'
-    }>,
-  ) {
-    await store.insertRun({
-      runId,
-      startedAt: daysAgo(failures[0]?.daysBack ?? 0).toISOString(),
-    })
-    await store.updateRun(runId, {
-      endedAt: new Date().toISOString(),
-      status: 'fail',
-      totalTests: failures.length + 5,
-      passedTests: 5,
-      failedTests: failures.length,
-    })
-    for (const f of failures) {
-      await store.insertFailure(
-        makeFailure(runId, f.name, daysAgo(f.daysBack), f.kind ?? 'assertion'),
-      )
-    }
-  }
-
-  test('returns empty when no failures exist', async () => {
-    const patterns = await store.getNewPatterns()
-    expect(patterns).toEqual([])
-  })
-
-  test('flags a test that crossed threshold in current window with no prior failures', async () => {
-    await seedRun('run-a', [
-      { name: 'auth > login', daysBack: 1 },
-      { name: 'auth > login', daysBack: 2 },
-    ])
-    const patterns = await store.getNewPatterns({ windowDays: 7, threshold: 2 })
-    expect(patterns).toHaveLength(1)
-    expect(patterns[0]?.testName).toBe('auth > login')
-    expect(patterns[0]?.recentFails).toBe(2)
-    expect(patterns[0]?.priorFails).toBe(0)
-  })
-
-  test('does not flag a test below threshold', async () => {
-    await seedRun('run-a', [{ name: 'auth > login', daysBack: 1 }])
-    const patterns = await store.getNewPatterns({ windowDays: 7, threshold: 2 })
-    expect(patterns).toHaveLength(0)
-  })
-
-  test('does not flag a test that also failed in the prior window', async () => {
-    await seedRun('run-a', [
-      { name: 'auth > login', daysBack: 1 }, // current window
-      { name: 'auth > login', daysBack: 2 }, // current window
-      { name: 'auth > login', daysBack: 10 }, // prior window (7-14 days ago)
-    ])
-    const patterns = await store.getNewPatterns({ windowDays: 7, threshold: 2 })
-    expect(patterns).toHaveLength(0)
-  })
-
-  test('does not flag a test with failures only in the prior window', async () => {
-    await seedRun('run-a', [
-      { name: 'auth > login', daysBack: 10 },
-      { name: 'auth > login', daysBack: 11 },
-    ])
-    const patterns = await store.getNewPatterns({ windowDays: 7, threshold: 2 })
-    expect(patterns).toHaveLength(0)
-  })
-
-  test('returns multiple patterns sorted by recentFails descending', async () => {
-    await seedRun('run-a', [
-      { name: 'test-a', daysBack: 1 },
-      { name: 'test-a', daysBack: 2 },
-      { name: 'test-a', daysBack: 3 },
-      { name: 'test-b', daysBack: 1 },
-      { name: 'test-b', daysBack: 2 },
-    ])
-    const patterns = await store.getNewPatterns({ windowDays: 7, threshold: 2 })
-    expect(patterns).toHaveLength(2)
-    expect(patterns[0]?.testName).toBe('test-a')
-    expect(patterns[0]?.recentFails).toBe(3)
-    expect(patterns[1]?.testName).toBe('test-b')
-    expect(patterns[1]?.recentFails).toBe(2)
-  })
-
-  test('respects custom threshold', async () => {
-    await seedRun('run-a', [
-      { name: 'flaky', daysBack: 1 },
-      { name: 'flaky', daysBack: 2 },
-    ])
-    expect(await store.getNewPatterns({ threshold: 3 })).toHaveLength(0)
-    expect(await store.getNewPatterns({ threshold: 2 })).toHaveLength(1)
-    expect(await store.getNewPatterns({ threshold: 1 })).toHaveLength(1)
-  })
-
-  test('collects distinct failure kinds', async () => {
-    await seedRun('run-a', [
-      { name: 'flaky', daysBack: 1, kind: 'assertion' },
-      { name: 'flaky', daysBack: 2, kind: 'timeout' },
-    ])
-    const patterns = await store.getNewPatterns({ threshold: 2 })
-    expect(patterns[0]?.failureKinds.sort()).toEqual(['assertion', 'timeout'])
-  })
-
-  test('includes lastErrorMessage from the most recent failure in the current window', async () => {
-    await store.insertRun({ runId: 'r1', startedAt: daysAgo(2).toISOString() })
-    await store.updateRun('r1', {
-      endedAt: new Date().toISOString(),
-      status: 'fail',
-      totalTests: 2,
-      passedTests: 0,
-      failedTests: 2,
-    })
-    await store.insertFailure({
-      runId: 'r1',
-      testFile: 'f.test.ts',
-      testName: 'flaky',
-      failureKind: 'assertion',
-      errorMessage: 'older error',
-      errorStack: null,
-      failedAt: daysAgo(2).toISOString(),
-    })
-    await store.insertFailure({
-      runId: 'r1',
-      testFile: 'f.test.ts',
-      testName: 'flaky',
-      failureKind: 'assertion',
-      errorMessage: 'newer error',
-      errorStack: null,
-      failedAt: daysAgo(1).toISOString(),
-    })
-
-    const patterns = await store.getNewPatterns({ threshold: 2 })
-    expect(patterns[0]?.lastErrorMessage).toBe('newer error')
-  })
-
-  test('excludes runs where failed_tests >= 10 (whole-suite crash, not flakiness)', async () => {
-    await store.insertRun({
-      runId: 'r-crash',
-      startedAt: daysAgo(1).toISOString(),
-    })
-    await store.updateRun('r-crash', {
-      endedAt: new Date().toISOString(),
-      status: 'fail',
-      totalTests: 50,
-      passedTests: 0,
-      failedTests: 50,
-    })
-    await store.insertFailure(
-      makeFailure('r-crash', 'auth > login', daysAgo(1)),
-    )
-    await store.insertFailure(
-      makeFailure('r-crash', 'auth > login', daysAgo(2)),
-    )
-
-    const patterns = await store.getNewPatterns({ threshold: 2 })
-    expect(patterns).toHaveLength(0)
   })
 })
 
@@ -265,5 +72,17 @@ describe('SqliteStore — reconcileRun', () => {
 
   test('does nothing for unknown runId', () => {
     expect(() => store.reconcileRun('no-such-run')).not.toThrow()
+  })
+
+  test('helpers (daysAgo, makeFailure) round-trip a failure', async () => {
+    await store.insertRun({ runId: 'r1', startedAt: new Date().toISOString() })
+    await store.updateRun('r1', {
+      endedAt: new Date().toISOString(),
+      status: 'fail',
+      totalTests: 1,
+      passedTests: 0,
+      failedTests: 1,
+    })
+    await store.insertFailure(makeFailure('r1', 'auth > login', daysAgo(0)))
   })
 })

--- a/packages/store-supabase/src/index.integration.test.ts
+++ b/packages/store-supabase/src/index.integration.test.ts
@@ -26,6 +26,11 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import { getTestCredentials } from '@flaky-tests/core'
+import {
+  daysAgo,
+  makeFailure,
+  runContractTests,
+} from '@flaky-tests/core/test-helpers'
 import { SupabaseStore } from './index'
 
 const credentials = getTestCredentials()
@@ -37,29 +42,19 @@ const SUPABASE_URL = credentials.supabaseUrl ?? ''
 const SUPABASE_KEY = credentials.supabaseKey ?? ''
 const TABLE_PREFIX = 'ft_integ'
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function daysAgo(n: number): Date {
-  return new Date(Date.now() - n * 86400000)
-}
-
-function makeFailure(
-  runId: string,
-  testName: string,
-  failedAt: Date,
-  kind = 'assertion' as const,
-) {
-  return {
-    runId,
-    testFile: 'tests/example.test.ts',
-    testName,
-    failureKind: kind,
-    errorMessage: `${testName} failed`,
-    errorStack: null,
-    failedAt: failedAt.toISOString(),
-  }
+// Shared IStore contract — each test builds a fresh SupabaseStore against
+// pre-created ft_integ_* tables; isolation is provided by per-test runIds
+// generated inside the contract suite.
+if (!SKIP) {
+  runContractTests(
+    'supabase',
+    () =>
+      new SupabaseStore({
+        url: SUPABASE_URL,
+        key: SUPABASE_KEY,
+        tablePrefix: TABLE_PREFIX,
+      }),
+  )
 }
 
 // Unique run IDs per test run to avoid collisions

--- a/packages/store-turso/src/index.integration.test.ts
+++ b/packages/store-turso/src/index.integration.test.ts
@@ -7,36 +7,24 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { type FailureKind, getTestCredentials } from '@flaky-tests/core'
+import { getTestCredentials } from '@flaky-tests/core'
+import {
+  daysAgo,
+  makeFailure,
+  runContractTests,
+} from '@flaky-tests/core/test-helpers'
 import { TursoStore } from './index'
 
 const credentials = getTestCredentials()
 const SKIP = !credentials.integration
 const TURSO_URL = credentials.tursoUrl ?? 'file::memory:'
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function daysAgo(n: number): Date {
-  return new Date(Date.now() - n * 86400000)
-}
-
-function makeFailure(
-  runId: string,
-  testName: string,
-  failedAt: Date,
-  kind: FailureKind = 'assertion',
-) {
-  return {
-    runId,
-    testFile: 'tests/example.test.ts',
-    testName,
-    failureKind: kind,
-    errorMessage: `${testName} failed`,
-    errorStack: null,
-    failedAt: failedAt.toISOString(),
-  }
+// Shared IStore contract — skipped unless INTEGRATION=1 is set.
+if (!SKIP) {
+  runContractTests('turso', async () => {
+    const store = new TursoStore({ url: TURSO_URL })
+    return store
+  })
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #25.

## Summary
- Every adapter (sqlite / turso / postgres / supabase) now invokes a shared 15-scenario `runContractTests(label, makeStore)` suite from `@flaky-tests/core/test-helpers`.
- Helpers (`daysAgo` / `makeRun` / `makeFailure`) that were duplicated across four test files with drift are now centralized.
- Adapter-specific tests (`reconcileRun`, `getDb`, duplicate-runId semantics) remain as supplements.

## Scenarios in the contract
| # | Scenario |
|---|---|
| 1 | insertRun → insertFailure → getNewPatterns reflects it |
| 2 | updateRun finalization gate (runs with null \`ended_at\` are ignored) |
| 3 | insertFailures batch writes all rows |
| 4 | Validation rejects malformed input before DB |
| 5 | No prior + above threshold → flagged |
| 6 | Prior + recent → NOT flagged |
| 7 | Below threshold → not flagged |
| 8 | Only prior → not flagged |
| 9 | Window edge: just-inside counts, just-outside does not |
| 10 | Custom threshold overrides default |
| 11 | Multiple patterns sorted by \`recentFails\` DESC |
| 12 | Distinct failure kinds collected |
| 13 | \`lastErrorMessage\` is most recent in current window |
| 14 | \`MAX_FAILED_TESTS_PER_RUN\` infra-blowup filter |
| 15 | \`close()\` is idempotent |

## Design decisions
- **Per-test factory** (\`() => IStore\`): every scenario starts with a fresh store. In-memory adapters get natural isolation; remote adapters (postgres/supabase) get isolation via \`crypto.randomUUID()\` runIds generated inside each test.
- **\`bun:test\` external** in the core build so \`dist/test-helpers/index.js\` stays small.
- **Integration-gate preserved**: turso/postgres/supabase are skipped unless \`INTEGRATION=1\` + credentials are set; sqlite runs on every commit.
- **Excluded from the contract**: duplicate-\`insertRun\` behavior (adapters disagree — PK violation vs. REST upsert) and FK enforcement on orphaned failures (supabase doesn't enforce by default). These remain adapter-specific tests where relevant.

## Verification
- [x] \`bun test\` — 249 pass / 0 fail (was 244 / 0)
- [x] \`bun run build\` — all packages clean, \`dist/test-helpers/\` emitted with types
- [x] \`bun run check\` — 0 errors
- [x] \`rg 'function (daysAgo|makeFailure|makeRun)' packages/\` — only hits in \`core/src/test-helpers/fixtures.ts\`

## Out of scope
- Changes to the \`IStore\` surface — the contract documents today's behavior.
- Backcompat shims for the moved helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)