### PR TITLE
feat(stores): SQL identifier injection unit tests for tablePrefix

### DIFF
--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -1,12 +1,18 @@
+import { ValidationError } from './validate-schemas'
+
 const TABLE_PREFIX_PATTERN = /^[a-z_][a-z0-9_]*$/
 
 /**
- * Validates a SQL table name prefix. Throws if the prefix contains
- * characters outside the safe identifier set `[a-z0-9_]`.
+ * Validates a SQL table name prefix. Throws {@link ValidationError} if the
+ * prefix contains characters outside the safe identifier set `[a-z0-9_]`.
+ *
+ * Interpolating a user-supplied string into a SQL identifier position
+ * (e.g. `${prefix}_runs`) is a path to identifier injection — this guard
+ * is the first line of defense; adapters should still quote identifiers.
  */
 export function validateTablePrefix(prefix: string): void {
   if (!TABLE_PREFIX_PATTERN.test(prefix)) {
-    throw new Error(
+    throw new ValidationError(
       `invalid tablePrefix: "${prefix}" — must match ${TABLE_PREFIX_PATTERN}`,
     )
   }

--- a/packages/store-postgres/src/index.test.ts
+++ b/packages/store-postgres/src/index.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test'
+import { ValidationError } from '@flaky-tests/core'
+import { PostgresStore } from './index'
+
+// Unit-tier: these never reach the DB — validation short-circuits in the
+// constructor before postgres() is called.
+
+describe('PostgresStore — tablePrefix validation', () => {
+  const malicious = [
+    '"; DROP TABLE --',
+    "'; DROP TABLE users; --",
+    'runs; DELETE FROM runs',
+    'runs"/*',
+    'runs OR 1=1',
+    'runs-with-hyphen',
+    'runs.with.dots',
+    '1_starts_with_digit',
+    '',
+  ] as const
+
+  for (const prefix of malicious) {
+    test(`rejects malicious tablePrefix: ${JSON.stringify(prefix)}`, () => {
+      expect(() => new PostgresStore({ tablePrefix: prefix })).toThrow(
+        ValidationError,
+      )
+    })
+  }
+
+  test('accepts a safe lowercase prefix', () => {
+    // We don't need a live connection for the constructor to succeed — the
+    // `postgres` client is built lazily. Just assert no throw.
+    expect(
+      () =>
+        new PostgresStore({
+          connectionString: 'postgres://localhost:5432/nope',
+          tablePrefix: 'flaky_test',
+        }),
+    ).not.toThrow()
+  })
+})

--- a/packages/store-supabase/src/index.test.ts
+++ b/packages/store-supabase/src/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { ValidationError } from '@flaky-tests/core'
+import { SupabaseStore } from './index'
+
+// Unit-tier: these never reach the network — validation short-circuits in
+// the constructor before createClient() is called.
+
+describe('SupabaseStore — tablePrefix validation', () => {
+  const malicious = [
+    '"; DROP TABLE --',
+    "'; DROP TABLE users; --",
+    'runs; DELETE FROM runs',
+    'runs"/*',
+    'runs OR 1=1',
+    'runs-with-hyphen',
+    'runs.with.dots',
+    '1_starts_with_digit',
+    '',
+  ] as const
+
+  for (const prefix of malicious) {
+    test(`rejects malicious tablePrefix: ${JSON.stringify(prefix)}`, () => {
+      expect(
+        () =>
+          new SupabaseStore({
+            url: 'https://example.supabase.co',
+            key: 'anon-key',
+            tablePrefix: prefix,
+          }),
+      ).toThrow(ValidationError)
+    })
+  }
+
+  test('accepts a safe lowercase prefix', () => {
+    expect(
+      () =>
+        new SupabaseStore({
+          url: 'https://example.supabase.co',
+          key: 'anon-key',
+          tablePrefix: 'flaky_test',
+        }),
+    ).not.toThrow()
+  })
+})

--- a/packages/store-supabase/src/index.ts
+++ b/packages/store-supabase/src/index.ts
@@ -53,11 +53,13 @@ export class SupabaseStore implements IStore {
   /** Validate options, construct a supabase-js client, and resolve the runs/failures table names from `tablePrefix` (default `flaky_test`). */
   constructor(options: SupabaseStoreOptions) {
     const validated = parse(supabaseStoreOptionsSchema, options)
-    this.client = createClient(validated.url, validated.key)
+    // Validate the prefix before creating any client — a malicious prefix
+    // should short-circuit with no observable side effects.
     const prefix = validated.tablePrefix ?? 'flaky_test'
     validateTablePrefix(prefix)
     this.runsTable = `${prefix}_runs`
     this.failuresTable = `${prefix}_failures`
+    this.client = createClient(validated.url, validated.key)
   }
 
   /**


### PR DESCRIPTION
Closes #26.

## Summary
- \`validateTablePrefix\` now throws \`ValidationError\` (was plain \`Error\`) so it joins the same error family as arktype validation — downstream catches already discriminate on \`ValidationError\`.
- \`SupabaseStore\` constructor now validates the prefix **before** \`createClient\`, so a malicious prefix short-circuits with zero observable side effects. (\`PostgresStore\` already did this.)
- New unit-tier tests (\`packages/store-{postgres,supabase}/src/index.test.ts\`) that construct the store with nine injection payloads — quoted SQL, comment-outs, \`OR 1=1\`, hyphens, dots, leading digits, empty string — and assert each throws \`ValidationError\` before any DB or network contact.

## Not in scope
Sqlite and turso do **not** expose a \`tablePrefix\` option — both use fixed \`runs\` / \`failures\` table names. There is no identifier-interpolation attack surface to protect on those adapters, so the \"all four stores\" acceptance box is only meaningful for the two stores that actually accept a prefix.

## Verification
- [x] \`bun test\`: 269 pass / 0 fail (was 249)
- [x] \`bun run build\`: clean
- [x] \`bun run check\`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)