### PR TITLE
chore: gitignore .claude/worktrees so biome skips nested configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ bun.lockb
 .local/
 .playwright-mcp/
 
+# Ephemeral git worktrees created via Claude's EnterWorktree helper.
+# Tracked-out copies of the repo live here; biome/tsc would otherwise
+# treat each nested biome.json as a conflicting root config.
+.claude/worktrees/
+
 # Per-package local credentials for live integration tests.
 # Loaded via `bun --env-file=packages/store-*/.env.local test …`.
 .env.local


### PR DESCRIPTION
## Summary
- Worktrees created via Claude Code's \`EnterWorktree\` helper live under \`.claude/worktrees/\`; each nested \`biome.json\` inside them was tripping biome 2.x's nested-root detection and failing every \`bun run check\` / \`biome lint\` invocation.
- Adding the path to \`.gitignore\` is enough — biome honors gitignore via \`vcs.useIgnoreFile: true\`.

## Verification
- [x] \`bun run check\` — \`Checked 117 files in 50ms. No fixes applied.\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)