### PR TITLE
feat(core+stores): retry with backoff for network store reads

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -27,11 +27,18 @@ const sqliteStoreConfigSchema = type({
   'module?': 'string',
 })
 
+/** Retry config shared by all network-backed stores; ignored by sqlite. */
+const retryConfigSchema = type({
+  'attempts?': 'number > 0',
+  'baseMs?': 'number > 0',
+})
+
 const tursoStoreConfigSchema = type({
   type: "'turso'",
   url: type.string.atLeastLength(1),
   'authToken?': 'string',
   'module?': 'string',
+  'retry?': retryConfigSchema,
 })
 
 const supabaseStoreConfigSchema = type({
@@ -40,6 +47,7 @@ const supabaseStoreConfigSchema = type({
   key: type.string.atLeastLength(1),
   'tablePrefix?': 'string',
   'module?': 'string',
+  'retry?': retryConfigSchema,
 })
 
 const postgresStoreConfigSchema = type({
@@ -53,6 +61,7 @@ const postgresStoreConfigSchema = type({
   'ssl?': "boolean | 'require' | 'prefer' | 'allow'",
   'tablePrefix?': 'string',
   'module?': 'string',
+  'retry?': retryConfigSchema,
 })
 
 /** Discriminated union on `type` — each variant carries only its own fields. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export {
   resetPluginRegistryForTesting,
 } from './plugin'
 export { generatePrompt } from './prompt'
+export { isRetryableError, type RetryOptions, withRetry } from './retry'
 export {
   failureKindSchema,
   flakyPatternSchema,

--- a/packages/core/src/retry.test.ts
+++ b/packages/core/src/retry.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from 'bun:test'
+import { computeBackoff, isRetryableError, withRetry } from './retry'
+
+// A sleep stub that resolves instantly so tests don't wait on real timers.
+const instantSleep = (): Promise<void> => Promise.resolve()
+
+describe('isRetryableError', () => {
+  test('ECONNRESET is retryable', () => {
+    expect(isRetryableError(new Error('read ECONNRESET'))).toBe(true)
+  })
+
+  test('ECONNREFUSED is retryable', () => {
+    expect(
+      isRetryableError(new Error('connect ECONNREFUSED 127.0.0.1:5432')),
+    ).toBe(true)
+  })
+
+  test('ETIMEDOUT is retryable', () => {
+    expect(isRetryableError(new Error('operation ETIMEDOUT'))).toBe(true)
+  })
+
+  test('"timed out" message is retryable', () => {
+    expect(isRetryableError(new Error('request timed out after 30s'))).toBe(
+      true,
+    )
+  })
+
+  test('HTTP 503 is retryable', () => {
+    const error = Object.assign(new Error('service unavailable'), {
+      status: 503,
+    })
+    expect(isRetryableError(error)).toBe(true)
+  })
+
+  test('HTTP 500 is retryable', () => {
+    const error = Object.assign(new Error('internal server error'), {
+      status: 500,
+    })
+    expect(isRetryableError(error)).toBe(true)
+  })
+
+  test('HTTP 400 is NOT retryable', () => {
+    const error = Object.assign(new Error('bad request'), { status: 400 })
+    expect(isRetryableError(error)).toBe(false)
+  })
+
+  test('HTTP 401 is NOT retryable', () => {
+    const error = Object.assign(new Error('unauthorized'), { status: 401 })
+    expect(isRetryableError(error)).toBe(false)
+  })
+
+  test('HTTP 429 is NOT retryable (caller handles rate limits explicitly)', () => {
+    const error = Object.assign(new Error('too many requests'), { status: 429 })
+    expect(isRetryableError(error)).toBe(false)
+  })
+
+  test('validation / assertion errors are NOT retryable', () => {
+    expect(isRetryableError(new Error('invalid input: field missing'))).toBe(
+      false,
+    )
+  })
+
+  test('status nested under .cause is read', () => {
+    const cause = Object.assign(new Error('upstream failed'), { status: 502 })
+    const error = Object.assign(new Error('wrapped'), { cause })
+    expect(isRetryableError(error)).toBe(true)
+  })
+})
+
+describe('withRetry', () => {
+  test('returns the op result on first success', async () => {
+    let calls = 0
+    const result = await withRetry(async () => {
+      calls++
+      return 'ok'
+    })
+    expect(result).toBe('ok')
+    expect(calls).toBe(1)
+  })
+
+  test('retries on a retryable error and returns once it succeeds', async () => {
+    let calls = 0
+    const result = await withRetry(
+      async () => {
+        calls++
+        if (calls < 3) throw new Error('ECONNRESET')
+        return 'eventually'
+      },
+      { attempts: 5, sleep: instantSleep },
+    )
+    expect(result).toBe('eventually')
+    expect(calls).toBe(3)
+  })
+
+  test('re-throws after exhausting attempts on persistent retryable error', async () => {
+    let calls = 0
+    await expect(
+      withRetry(
+        async () => {
+          calls++
+          throw new Error('ECONNRESET')
+        },
+        { attempts: 3, sleep: instantSleep },
+      ),
+    ).rejects.toThrow('ECONNRESET')
+    expect(calls).toBe(3)
+  })
+
+  test('does NOT retry on non-retryable errors — fails fast', async () => {
+    let calls = 0
+    const error = Object.assign(new Error('bad request'), { status: 400 })
+    await expect(
+      withRetry(
+        async () => {
+          calls++
+          throw error
+        },
+        { attempts: 5, sleep: instantSleep },
+      ),
+    ).rejects.toBe(error)
+    expect(calls).toBe(1)
+  })
+
+  test('already-aborted signal throws before any call', async () => {
+    const controller = new AbortController()
+    controller.abort(new Error('cancelled'))
+    let calls = 0
+    await expect(
+      withRetry(
+        async () => {
+          calls++
+          return 'never'
+        },
+        { signal: controller.signal, sleep: instantSleep },
+      ),
+    ).rejects.toThrow('cancelled')
+    expect(calls).toBe(0)
+  })
+
+  test('signal abort during sleep propagates and stops retrying', async () => {
+    let calls = 0
+    // The real `defaultSleep` rejects with the signal's reason when aborted;
+    // we model that directly here so we don't depend on wall-clock timing.
+    const rejectingSleep = (): Promise<void> =>
+      Promise.reject(new Error('cancelled during sleep'))
+    await expect(
+      withRetry(
+        async () => {
+          calls++
+          throw new Error('ECONNRESET')
+        },
+        { attempts: 5, sleep: rejectingSleep },
+      ),
+    ).rejects.toThrow('cancelled during sleep')
+    expect(calls).toBe(1)
+  })
+
+  test('attempts: 1 disables retry entirely', async () => {
+    let calls = 0
+    await expect(
+      withRetry(
+        async () => {
+          calls++
+          throw new Error('ECONNRESET')
+        },
+        { attempts: 1, sleep: instantSleep },
+      ),
+    ).rejects.toThrow('ECONNRESET')
+    expect(calls).toBe(1)
+  })
+
+  test('rejects invalid attempts config', async () => {
+    await expect(withRetry(async () => 'x', { attempts: 0 })).rejects.toThrow(
+      'positive integer',
+    )
+    await expect(withRetry(async () => 'x', { attempts: 1.5 })).rejects.toThrow(
+      'positive integer',
+    )
+  })
+
+  test('custom isRetryable overrides the default classifier', async () => {
+    let calls = 0
+    const result = await withRetry(
+      async () => {
+        calls++
+        if (calls < 2) throw new Error('totally custom error we chose to retry')
+        return 'done'
+      },
+      { attempts: 3, sleep: instantSleep, isRetryable: () => true },
+    )
+    expect(result).toBe('done')
+    expect(calls).toBe(2)
+  })
+})
+
+describe('computeBackoff', () => {
+  test('stays within the 0.5x..1x jitter window of the deterministic delay', () => {
+    const base = 100
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      const deterministic = base * 2 ** (attempt - 1)
+      for (let i = 0; i < 50; i++) {
+        const actual = computeBackoff(base, attempt)
+        expect(actual).toBeGreaterThanOrEqual(Math.round(deterministic * 0.5))
+        expect(actual).toBeLessThanOrEqual(deterministic)
+      }
+    }
+  })
+})

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -1,0 +1,167 @@
+import { createLogger } from './log'
+
+const log = createLogger('retry')
+
+/** Options accepted by {@link withRetry}. */
+export interface RetryOptions {
+  /** Max attempts including the first. Must be >= 1. Default 3. */
+  attempts?: number
+  /** Base delay in milliseconds between attempts. Default 100. */
+  baseMs?: number
+  /** Abort pending sleeps and reject with the signal's reason. */
+  signal?: AbortSignal | undefined
+  /**
+   * Hook for injecting a sleep implementation. Defaults to `setTimeout`.
+   * Exists so tests can run retry logic without wall-clock delays.
+   */
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>
+  /**
+   * Hook for overriding the retryable-error classifier. Defaults to
+   * {@link isRetryableError}. Tests use this to force specific branches;
+   * callers rarely need to touch it.
+   */
+  isRetryable?: (error: unknown) => boolean
+}
+
+const DEFAULT_ATTEMPTS = 3
+const DEFAULT_BASE_MS = 100
+const BACKOFF_MULTIPLIER = 2
+const JITTER_FLOOR = 0.5
+const HTTP_STATUS_SERVER_ERROR_MIN = 500
+const HTTP_STATUS_SERVER_ERROR_MAX_EXCLUSIVE = 600
+const HTTP_STATUS_CLIENT_ERROR_MIN = 400
+const HTTP_STATUS_CLIENT_ERROR_MAX_EXCLUSIVE = 500
+
+/** Sleep for `ms` milliseconds, rejecting if `signal` aborts before the timer fires. */
+function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted === true) {
+      reject(signal.reason)
+      return
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = (): void => {
+      clearTimeout(timer)
+      reject(signal?.reason)
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/**
+ * Error-message substrings we consider transient — safe to retry because a
+ * fresh connection or a moment later usually clears them. Kept as a tight
+ * whitelist so we never retry logic/authorization errors by accident.
+ */
+const RETRYABLE_CODE_PATTERNS: readonly RegExp[] = [
+  /\bECONNRESET\b/,
+  /\bECONNREFUSED\b/,
+  /\bETIMEDOUT\b/,
+  /\bENETUNREACH\b/,
+  /\bEAI_AGAIN\b/,
+  /\btimed?\s*out\b/i,
+  /\bfetch failed\b/i,
+  /\bsocket hang up\b/i,
+]
+
+/** Dig out a numeric HTTP status from the common error shapes we see across drivers. */
+function extractStatus(error: unknown): number | null {
+  if (typeof error !== 'object' || error === null) return null
+  const bag = error as Record<string, unknown>
+  const candidates = [bag.status, bag.statusCode, bag.code]
+  for (const candidate of candidates) {
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      return candidate
+    }
+  }
+  // supabase-js nests `{ error: { status } }`; postgres.js uses `severity` + string codes we don't retry on.
+  if (typeof bag.cause === 'object' && bag.cause !== null) {
+    return extractStatus(bag.cause)
+  }
+  return null
+}
+
+/**
+ * Classifies an error as retryable. Returns `true` for:
+ * - network transport failures (ECONNRESET, ECONNREFUSED, ETIMEDOUT, ENETUNREACH, EAI_AGAIN)
+ * - timeout messages ("timed out", "timeout")
+ * - HTTP 5xx
+ *
+ * Returns `false` for HTTP 4xx, validation errors, and anything we don't
+ * recognize. The default is deliberately conservative — unknown errors stay
+ * non-retryable so we don't mask logic bugs behind retry loops.
+ */
+export function isRetryableError(error: unknown): boolean {
+  const status = extractStatus(error)
+  if (status !== null) {
+    if (
+      status >= HTTP_STATUS_SERVER_ERROR_MIN &&
+      status < HTTP_STATUS_SERVER_ERROR_MAX_EXCLUSIVE
+    )
+      return true
+    if (
+      status >= HTTP_STATUS_CLIENT_ERROR_MIN &&
+      status < HTTP_STATUS_CLIENT_ERROR_MAX_EXCLUSIVE
+    )
+      return false
+  }
+  const message = error instanceof Error ? error.message : String(error)
+  return RETRYABLE_CODE_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+/**
+ * Run `op` with exponential backoff on retryable failures. Retries only on
+ * network/5xx errors per {@link isRetryableError}; re-throws everything else
+ * immediately so logic and 4xx errors surface fast.
+ *
+ * Backoff schedule: `baseMs * 2^(attempt-1)` with jitter in `[0.5, 1)x` of
+ * that delay. An `AbortSignal` cancels any pending sleep and rejects with
+ * the signal's reason.
+ *
+ * On exhaustion, re-throws the last caught error so callers see the real
+ * driver exception (wrapped in `StoreError` by the store adapter's own
+ * `wrap` helper).
+ */
+export async function withRetry<T>(
+  op: () => Promise<T>,
+  opts: RetryOptions = {},
+): Promise<T> {
+  const attempts = opts.attempts ?? DEFAULT_ATTEMPTS
+  const baseMs = opts.baseMs ?? DEFAULT_BASE_MS
+  const sleep = opts.sleep ?? defaultSleep
+  const classify = opts.isRetryable ?? isRetryableError
+  if (attempts < 1 || !Number.isInteger(attempts)) {
+    throw new TypeError(
+      `withRetry: attempts must be a positive integer, got ${attempts}`,
+    )
+  }
+  opts.signal?.throwIfAborted()
+
+  let lastError: unknown
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await op()
+    } catch (error) {
+      lastError = error
+      if (!classify(error)) throw error
+      if (attempt === attempts) throw error
+      const delay = computeBackoff(baseMs, attempt)
+      log.debug(
+        `retry ${attempt}/${attempts - 1} after ${delay}ms: ${error instanceof Error ? error.message : String(error)}`,
+      )
+      await sleep(delay, opts.signal)
+    }
+  }
+  // Unreachable — the loop either returns or throws.
+  throw lastError
+}
+
+/** Exposed for tests so they can assert the jitter bounds directly. */
+export function computeBackoff(baseMs: number, attempt: number): number {
+  const deterministic = baseMs * BACKOFF_MULTIPLIER ** (attempt - 1)
+  const jitter = JITTER_FLOOR + Math.random() * JITTER_FLOOR
+  return Math.round(deterministic * jitter)
+}

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -21,17 +21,30 @@ import {
   parse,
   parseArray,
   type RecentRun,
+  type RetryOptions,
   type RunStatus,
   StoreError,
   type UpdateRunInput,
   updateRunInputSchema,
   validateTablePrefix,
+  withRetry,
 } from '@flaky-tests/core'
 import { type } from 'arktype'
 import postgres from 'postgres'
 
 const log = createLogger('store-postgres')
 const PACKAGE = '@flaky-tests/store-postgres'
+
+/**
+ * Retry tuning for read methods. Defaults to 3 attempts / 100ms base from
+ * {@link withRetry}. Writes are not retried because {@link IStore.insertFailure}
+ * has no idempotency key — a retried write that succeeded server-side would
+ * double-insert.
+ */
+export const retryOptionsSchema = type({
+  'attempts?': 'number > 0',
+  'baseMs?': 'number > 0',
+})
 
 /** Configuration for the PostgreSQL store. */
 export const postgresStoreOptionsSchema = type({
@@ -43,6 +56,7 @@ export const postgresStoreOptionsSchema = type({
   'password?': 'string',
   'ssl?': "boolean | 'require' | 'prefer' | 'allow'",
   'tablePrefix?': 'string',
+  'retry?': retryOptionsSchema,
 })
 
 /** Inferred options type for constructing a {@link PostgresStore}. */
@@ -91,6 +105,7 @@ export class PostgresStore implements IStore {
   private sql: ReturnType<typeof postgres>
   private runsTable: string
   private failuresTable: string
+  private retryOptions: RetryOptions
 
   /** Accepts either a full `connectionString` or individual host/port/credentials fields. */
   constructor(options: PostgresStoreOptions = {}) {
@@ -99,6 +114,7 @@ export class PostgresStore implements IStore {
     validateTablePrefix(prefix)
     this.runsTable = `${prefix}_runs`
     this.failuresTable = `${prefix}_failures`
+    this.retryOptions = validated.retry ?? {}
 
     if (validated.connectionString) {
       this.sql = postgres(validated.connectionString)
@@ -295,41 +311,46 @@ export class PostgresStore implements IStore {
         ? this.sql`r.project IS NULL`
         : this.sql`r.project = ${project}`
 
-    const rows = await this.wrap('getNewPatterns', () => {
-      const query = this.sql<
-        Array<{
-          test_file: string
-          test_name: string
-          recent_fails: string
-          prior_fails: string
-          failure_kinds: string[]
-          last_error_message_raw: string | null
-          last_error_stack_raw: string | null
-          last_failed: Date
-        }>
-      >`
-        SELECT
-          f.test_file,
-          f.test_name,
-          COUNT(*) FILTER (WHERE f.failed_at > ${windowStart})                                    AS recent_fails,
-          COUNT(*) FILTER (WHERE f.failed_at <= ${windowStart} AND f.failed_at > ${priorStart})   AS prior_fails,
-          ARRAY_AGG(DISTINCT f.failure_kind)                                                       AS failure_kinds,
-          MAX(f.failed_at::text || chr(1) || f.error_message) FILTER (WHERE f.failed_at > ${windowStart} AND f.error_message IS NOT NULL) AS last_error_message_raw,
-          MAX(f.failed_at::text || chr(1) || f.error_stack)  FILTER (WHERE f.failed_at > ${windowStart} AND f.error_stack IS NOT NULL)  AS last_error_stack_raw,
-          MAX(f.failed_at)                                                                         AS last_failed
-        FROM ${this.sql(failures)} f
-        JOIN ${this.sql(runs)} r ON r.run_id = f.run_id
-        WHERE r.failed_tests < ${MAX_FAILED_TESTS_PER_RUN}
-          AND r.ended_at IS NOT NULL
-          AND f.failed_at > ${priorStart}
-          AND ${projectFilter}
-        GROUP BY f.test_file, f.test_name
-        HAVING COUNT(*) FILTER (WHERE f.failed_at > ${windowStart}) >= ${threshold}
-           AND COUNT(*) FILTER (WHERE f.failed_at <= ${windowStart} AND f.failed_at > ${priorStart}) = 0
-        ORDER BY recent_fails DESC
-      `
-      return cancelOnAbort(query, options.signal)
-    })
+    const rows = await this.wrap('getNewPatterns', () =>
+      withRetry(
+        () => {
+          const query = this.sql<
+            Array<{
+              test_file: string
+              test_name: string
+              recent_fails: string
+              prior_fails: string
+              failure_kinds: string[]
+              last_error_message_raw: string | null
+              last_error_stack_raw: string | null
+              last_failed: Date
+            }>
+          >`
+            SELECT
+              f.test_file,
+              f.test_name,
+              COUNT(*) FILTER (WHERE f.failed_at > ${windowStart})                                    AS recent_fails,
+              COUNT(*) FILTER (WHERE f.failed_at <= ${windowStart} AND f.failed_at > ${priorStart})   AS prior_fails,
+              ARRAY_AGG(DISTINCT f.failure_kind)                                                       AS failure_kinds,
+              MAX(f.failed_at::text || chr(1) || f.error_message) FILTER (WHERE f.failed_at > ${windowStart} AND f.error_message IS NOT NULL) AS last_error_message_raw,
+              MAX(f.failed_at::text || chr(1) || f.error_stack)  FILTER (WHERE f.failed_at > ${windowStart} AND f.error_stack IS NOT NULL)  AS last_error_stack_raw,
+              MAX(f.failed_at)                                                                         AS last_failed
+            FROM ${this.sql(failures)} f
+            JOIN ${this.sql(runs)} r ON r.run_id = f.run_id
+            WHERE r.failed_tests < ${MAX_FAILED_TESTS_PER_RUN}
+              AND r.ended_at IS NOT NULL
+              AND f.failed_at > ${priorStart}
+              AND ${projectFilter}
+            GROUP BY f.test_file, f.test_name
+            HAVING COUNT(*) FILTER (WHERE f.failed_at > ${windowStart}) >= ${threshold}
+               AND COUNT(*) FILTER (WHERE f.failed_at <= ${windowStart} AND f.failed_at > ${priorStart}) = 0
+            ORDER BY recent_fails DESC
+          `
+          return cancelOnAbort(query, options.signal)
+        },
+        { ...this.retryOptions, signal: options.signal },
+      ),
+    )
 
     const patterns = parseArray(flakyPatternSchema, rows.map(mapRowToPattern))
     log.debug(
@@ -347,33 +368,38 @@ export class PostgresStore implements IStore {
       project === null
         ? this.sql`project IS NULL`
         : this.sql`project = ${project}`
-    const rows = await this.wrap('getRecentRuns', () => {
-      const query = this.sql<
-        Array<{
-          run_id: string
-          project: string | null
-          started_at: Date
-          ended_at: Date | null
-          duration_ms: number | null
-          status: string | null
-          total_tests: number | null
-          passed_tests: number | null
-          failed_tests: number | null
-          errors_between_tests: number | null
-          git_sha: string | null
-          git_dirty: boolean | null
-        }>
-      >`
-        SELECT run_id, project, started_at, ended_at, duration_ms, status,
-               total_tests, passed_tests, failed_tests,
-               errors_between_tests, git_sha, git_dirty
-          FROM ${this.sql(runs)}
-         WHERE ${projectFilter}
-         ORDER BY started_at DESC
-         LIMIT ${limit}
-      `
-      return cancelOnAbort(query, signal)
-    })
+    const rows = await this.wrap('getRecentRuns', () =>
+      withRetry(
+        () => {
+          const query = this.sql<
+            Array<{
+              run_id: string
+              project: string | null
+              started_at: Date
+              ended_at: Date | null
+              duration_ms: number | null
+              status: string | null
+              total_tests: number | null
+              passed_tests: number | null
+              failed_tests: number | null
+              errors_between_tests: number | null
+              git_sha: string | null
+              git_dirty: boolean | null
+            }>
+          >`
+            SELECT run_id, project, started_at, ended_at, duration_ms, status,
+                   total_tests, passed_tests, failed_tests,
+                   errors_between_tests, git_sha, git_dirty
+              FROM ${this.sql(runs)}
+             WHERE ${projectFilter}
+             ORDER BY started_at DESC
+             LIMIT ${limit}
+          `
+          return cancelOnAbort(query, signal)
+        },
+        { ...this.retryOptions, signal },
+      ),
+    )
     const toIso = (value: Date | string | null): string | null => {
       if (value === null) return null
       if (value instanceof Date) return value.toISOString()

--- a/packages/store-supabase/src/index.ts
+++ b/packages/store-supabase/src/index.ts
@@ -19,11 +19,13 @@ import {
   parse,
   parseArray,
   type RecentRun,
+  type RetryOptions,
   type RunStatus,
   StoreError,
   type UpdateRunInput,
   updateRunInputSchema,
   validateTablePrefix,
+  withRetry,
 } from '@flaky-tests/core'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createClient } from '@supabase/supabase-js'
@@ -31,11 +33,23 @@ import { type } from 'arktype'
 
 const log = createLogger('store-supabase')
 
+/**
+ * Retry tuning for read methods. Defaults to 3 attempts / 100ms base from
+ * {@link withRetry}. Writes are not retried because `insertFailure` lacks an
+ * idempotency key — a retried write that succeeded server-side would
+ * double-insert.
+ */
+export const retryOptionsSchema = type({
+  'attempts?': 'number > 0',
+  'baseMs?': 'number > 0',
+})
+
 /** Configuration for the Supabase store. */
 export const supabaseStoreOptionsSchema = type({
   url: type.string.atLeastLength(1),
   key: type.string.atLeastLength(1),
   'tablePrefix?': 'string',
+  'retry?': retryOptionsSchema,
 })
 
 /** Validated options accepted by {@link SupabaseStore}. Inferred from the ArkType schema so runtime and compile-time stay aligned. */
@@ -52,6 +66,7 @@ export class SupabaseStore implements IStore {
   private client: SupabaseClient
   private runsTable: string
   private failuresTable: string
+  private retryOptions: RetryOptions
 
   /** Validate options, construct a supabase-js client, and resolve the runs/failures table names from `tablePrefix` (default `flaky_test`). */
   constructor(options: SupabaseStoreOptions) {
@@ -63,6 +78,7 @@ export class SupabaseStore implements IStore {
     this.runsTable = `${prefix}_runs`
     this.failuresTable = `${prefix}_failures`
     this.client = createClient(validated.url, validated.key)
+    this.retryOptions = validated.retry ?? {}
   }
 
   /**
@@ -207,33 +223,45 @@ export class SupabaseStore implements IStore {
 
     const project = validated.project ?? null
 
-    // Fetch failures from both windows in one query, filter to relevant runs
-    let query = this.client
-      .from(this.failuresTable)
-      .select(`run_id, test_file, test_name, failure_kind, error_message, error_stack, failed_at,
-               ${this.runsTable}!inner(failed_tests, ended_at, project)`)
-      .gt('failed_at', priorStart)
-      .lt(`${this.runsTable}.failed_tests`, MAX_FAILED_TESTS_PER_RUN)
-      .not(`${this.runsTable}.ended_at`, 'is', null)
-    query =
-      project === null
-        ? query.is(`${this.runsTable}.project`, null)
-        : query.eq(`${this.runsTable}.project`, project)
-    const finalized =
-      options.signal !== undefined ? query.abortSignal(options.signal) : query
-    const { data, error } = await finalized
-
-    // postgrest-js surfaces an aborted fetch as a regular error; the signal
-    // itself is the authoritative source — if it aborted mid-flight, throw
-    // its reason so callers see a native AbortError across adapters.
-    options.signal?.throwIfAborted()
-    if (error)
+    // Each retry attempt rebuilds the postgrest query — the builder mutates
+    // internal state, so reuse across attempts would send malformed requests.
+    const runQuery = async (): Promise<unknown[]> => {
+      let query = this.client
+        .from(this.failuresTable)
+        .select(`run_id, test_file, test_name, failure_kind, error_message, error_stack, failed_at,
+                 ${this.runsTable}!inner(failed_tests, ended_at, project)`)
+        .gt('failed_at', priorStart)
+        .lt(`${this.runsTable}.failed_tests`, MAX_FAILED_TESTS_PER_RUN)
+        .not(`${this.runsTable}.ended_at`, 'is', null)
+      query =
+        project === null
+          ? query.is(`${this.runsTable}.project`, null)
+          : query.eq(`${this.runsTable}.project`, project)
+      const finalized =
+        options.signal !== undefined ? query.abortSignal(options.signal) : query
+      const { data, error } = await finalized
+      // postgrest-js surfaces an aborted fetch as a regular error; the signal
+      // itself is the authoritative source — if it aborted mid-flight, throw
+      // its reason so callers see a native AbortError across adapters.
+      options.signal?.throwIfAborted()
+      if (error) throw error
+      return (data ?? []) as unknown[]
+    }
+    let data: unknown[]
+    try {
+      data = await withRetry(runQuery, {
+        ...this.retryOptions,
+        signal: options.signal,
+      })
+    } catch (error) {
+      options.signal?.throwIfAborted()
       throw new StoreError({
         package: PACKAGE,
         method: 'getNewPatterns',
-        message: error.message,
+        message: error instanceof Error ? error.message : String(error),
         cause: error,
       })
+    }
 
     type Row = {
       test_file: string
@@ -244,7 +272,7 @@ export class SupabaseStore implements IStore {
       failed_at: string
     }
     // Supabase client returns typed JSON but the generic is too wide — Row matches the select columns above
-    const rows = (data ?? []) as unknown as Row[]
+    const rows = data as unknown as Row[]
 
     // Group and compute counts per test
     const map = new Map<
@@ -318,27 +346,36 @@ export class SupabaseStore implements IStore {
   async getRecentRuns(options: GetRecentRunsOptions): Promise<RecentRun[]> {
     options.signal?.throwIfAborted()
     const { limit, project = null, signal } = options
-    let query = this.client
-      .from(this.runsTable)
-      .select(
-        'run_id, project, started_at, ended_at, duration_ms, status, total_tests, passed_tests, failed_tests, errors_between_tests, git_sha, git_dirty',
-      )
-      .order('started_at', { ascending: false })
-      .limit(limit)
-    query =
-      project === null
-        ? query.is('project', null)
-        : query.eq('project', project)
-    const finalized = signal !== undefined ? query.abortSignal(signal) : query
-    const { data, error } = await finalized
-    signal?.throwIfAborted()
-    if (error)
+    const runQuery = async (): Promise<unknown[]> => {
+      let query = this.client
+        .from(this.runsTable)
+        .select(
+          'run_id, project, started_at, ended_at, duration_ms, status, total_tests, passed_tests, failed_tests, errors_between_tests, git_sha, git_dirty',
+        )
+        .order('started_at', { ascending: false })
+        .limit(limit)
+      query =
+        project === null
+          ? query.is('project', null)
+          : query.eq('project', project)
+      const finalized = signal !== undefined ? query.abortSignal(signal) : query
+      const { data, error } = await finalized
+      signal?.throwIfAborted()
+      if (error) throw error
+      return (data ?? []) as unknown[]
+    }
+    let data: unknown[]
+    try {
+      data = await withRetry(runQuery, { ...this.retryOptions, signal })
+    } catch (error) {
+      signal?.throwIfAborted()
       throw new StoreError({
         package: PACKAGE,
         method: 'getRecentRuns',
-        message: error.message,
+        message: error instanceof Error ? error.message : String(error),
         cause: error,
       })
+    }
     type Row = {
       run_id: string
       project: string | null
@@ -353,7 +390,7 @@ export class SupabaseStore implements IStore {
       git_sha: string | null
       git_dirty: boolean | null
     }
-    return ((data ?? []) as unknown as Row[]).map((row) => ({
+    return (data as unknown as Row[]).map((row) => ({
       runId: row.run_id,
       project: row.project,
       startedAt: row.started_at,
@@ -391,6 +428,7 @@ export const supabaseStorePlugin = definePlugin({
       ...(config.store.tablePrefix !== undefined && {
         tablePrefix: config.store.tablePrefix,
       }),
+      ...(config.store.retry !== undefined && { retry: config.store.retry }),
     })
   },
 })

--- a/packages/store-turso/src/index.ts
+++ b/packages/store-turso/src/index.ts
@@ -22,11 +22,13 @@ import {
   parse,
   parseArray,
   type RecentRun,
+  type RetryOptions,
   type RunStatus,
   raceAbort,
   StoreError,
   type UpdateRunInput,
   updateRunInputSchema,
+  withRetry,
 } from '@flaky-tests/core'
 import type { Client, InArgs } from '@libsql/client'
 import { createClient } from '@libsql/client'
@@ -35,10 +37,22 @@ import { type } from 'arktype'
 const log = createLogger('store-turso')
 const PACKAGE = '@flaky-tests/store-turso'
 
+/**
+ * Retry tuning for read methods. Defaults — 3 attempts, 100ms base — come
+ * from {@link withRetry}; override per-store to disable (attempts=1) or
+ * extend the backoff window. Applies only to read methods; writes are not
+ * retried because {@link IStore.insertFailure} lacks an idempotency key.
+ */
+export const retryOptionsSchema = type({
+  'attempts?': 'number > 0',
+  'baseMs?': 'number > 0',
+})
+
 /** Configuration for the Turso (libSQL) store. */
 export const tursoStoreOptionsSchema = type({
   url: type.string.atLeastLength(1),
   'authToken?': 'string',
+  'retry?': retryOptionsSchema,
 })
 
 /** Inferred options type for {@link TursoStore}: libSQL URL plus optional HTTP auth token. */
@@ -88,6 +102,7 @@ CREATE INDEX IF NOT EXISTS idx_runs_status        ON runs(ended_at, failed_tests
  */
 export class TursoStore implements IStore {
   private client: Client
+  private retryOptions: RetryOptions
 
   /** Builds the libSQL client from a validated URL and optional auth token. */
   constructor(options: TursoStoreOptions) {
@@ -98,6 +113,7 @@ export class TursoStore implements IStore {
         authToken: validated.authToken,
       }),
     })
+    this.retryOptions = validated.retry ?? {}
   }
 
   /** Wraps a driver call so any thrown libSQL error becomes a {@link StoreError} with `cause` preserved for stack inspection. */
@@ -281,9 +297,11 @@ export class TursoStore implements IStore {
     // observe an AbortError immediately while the request completes in the
     // background and is discarded.
     const result = await this.wrap('getNewPatterns', () =>
-      raceAbort(
-        this.client.execute({
-          sql: `SELECT
+      withRetry(
+        () =>
+          raceAbort(
+            this.client.execute({
+              sql: `SELECT
                  f.test_file,
                  f.test_name,
                  SUM(CASE WHEN f.failed_at > ?  THEN 1 ELSE 0 END) AS recent_fails,
@@ -303,9 +321,11 @@ export class TursoStore implements IStore {
               GROUP BY f.test_file, f.test_name
               HAVING recent_fails >= ? AND prior_fails = 0
               ORDER BY recent_fails DESC`,
-          args: args as InArgs,
-        }),
-        options.signal,
+              args: args as InArgs,
+            }),
+            options.signal,
+          ),
+        { ...this.retryOptions, signal: options.signal },
       ),
     )
 
@@ -327,18 +347,22 @@ export class TursoStore implements IStore {
     const projectClause = project === null ? 'project IS NULL' : 'project = ?'
     const args = project === null ? [limit] : [project, limit]
     const result = await this.wrap('getRecentRuns', () =>
-      raceAbort(
-        this.client.execute({
-          sql: `SELECT run_id, project, started_at, ended_at, duration_ms, status,
+      withRetry(
+        () =>
+          raceAbort(
+            this.client.execute({
+              sql: `SELECT run_id, project, started_at, ended_at, duration_ms, status,
                        total_tests, passed_tests, failed_tests,
                        errors_between_tests, git_sha, git_dirty
                   FROM runs
                  WHERE ${projectClause}
                  ORDER BY started_at DESC
                  LIMIT ?`,
-          args: args as InArgs,
-        }),
-        signal,
+              args: args as InArgs,
+            }),
+            signal,
+          ),
+        { ...this.retryOptions, signal },
       ),
     )
     return result.rows.map((row) => {
@@ -386,6 +410,7 @@ export const tursoStorePlugin = definePlugin({
       ...(config.store.authToken !== undefined && {
         authToken: config.store.authToken,
       }),
+      ...(config.store.retry !== undefined && { retry: config.store.retry }),
     })
   },
 })


### PR DESCRIPTION
## Summary

- New `withRetry` helper in `@flaky-tests/core` — exponential backoff + jitter, AbortSignal support, narrow retryable-error whitelist.
- Network stores (turso, postgres, supabase) wrap their **read methods** (`getNewPatterns`, `getRecentRuns`) in `withRetry` by default.
- Per-store `retry: { attempts?, baseMs? }` option; defaults 3 / 100ms; `attempts: 1` disables retry entirely.
- sqlite unchanged — synchronous, no retryable failures.

Closes #29

## Why retry reads only

Writes (`insertFailure`, `insertFailures`) are deliberately **not** retried: they have no idempotency key, so a retried write that succeeded server-side would double-insert. Adding a unique constraint + `ON CONFLICT DO NOTHING` is a prerequisite; tracking that as a separate PR per the issue's ""Do NOT"" section.

## Retry classifier

Retries on:
- `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `ENETUNREACH`, `EAI_AGAIN`
- `timed out` / `timeout` messages
- `fetch failed`, `socket hang up`
- HTTP 5xx (read from `.status` / `.statusCode` / `.code`, recursively through `.cause`)

Does NOT retry:
- HTTP 4xx (including 429 — callers handle rate limits explicitly)
- Validation / logic errors — fails fast
- Anything else — conservative default, unknown errors surface rather than getting masked behind a loop

## Test plan

- [x] `bun run typecheck` — 8 configs clean
- [x] `bun run check` — biome clean
- [x] `bun test` — 310 pass (21 new retry tests covering fast success, retry-then-success, exhaustion, non-retryable passthrough, already-aborted signal, signal-during-sleep, `attempts: 1` disables, invalid-attempts rejection, custom classifier override, backoff jitter bounds)
- [x] `INTEGRATION=1 bun test packages/store-turso` — 31 pass
- [ ] Postgres + supabase integration — rely on CI secrets

## Out of scope

- Retrying writes (needs idempotency keys first)
- Retry on sqlite (synchronous, not retryable)
- Secret redaction (kept separate per issue note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)