### PR TITLE
test(core): regression tests for DescribeStack depth limit (closes #33)

### DIFF
--- a/packages/core/src/describe-stack.test.ts
+++ b/packages/core/src/describe-stack.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test'
-import { DescribeStack } from './describe-stack'
+import { DescribeStack, MAX_DESCRIBE_DEPTH } from './describe-stack'
+
+/** Drive the stack to the requested depth by recursively calling `run()`. */
+function nestTo(stack: DescribeStack, depth: number): void {
+  if (depth === 0) return
+  stack.run(`d${depth}`, () => nestTo(stack, depth - 1))
+}
 
 describe('DescribeStack', () => {
   test('starts with depth 0', () => {
@@ -84,6 +90,60 @@ describe('DescribeStack', () => {
         /* expected */
       }
       expect(stack.path('test')).toBe('A > test')
+    })
+  })
+
+  // --- Depth-limit regression tests (issue #33) --------------------------
+  // Values are hardcoded to 256 / 257 so any change to MAX_DESCRIBE_DEPTH
+  // surfaces as a test failure — the guard is a behavioral contract.
+
+  test('MAX_DESCRIBE_DEPTH is the documented 256 limit', () => {
+    expect(MAX_DESCRIBE_DEPTH).toBe(256)
+  })
+
+  test('run() succeeds at 256 frames deep', () => {
+    const stack = new DescribeStack()
+    let observedDepth = 0
+    const recurse = (depth: number): void => {
+      if (depth === 0) {
+        observedDepth = stack.depth
+        return
+      }
+      stack.run(`d${depth}`, () => recurse(depth - 1))
+    }
+    expect(() => recurse(256)).not.toThrow()
+    expect(observedDepth).toBe(256)
+    expect(stack.depth).toBe(0)
+  })
+
+  test('run() throws RangeError on the 257th frame', () => {
+    const stack = new DescribeStack()
+    expect(() => nestTo(stack, 257)).toThrow(RangeError)
+  })
+
+  test('runWithFrames() rejects a frames array longer than 256', () => {
+    const stack = new DescribeStack()
+    const tooManyFrames = Array.from({ length: 257 }, (_, i) => `f${i}`)
+    expect(() => stack.runWithFrames(tooManyFrames, () => undefined)).toThrow(
+      RangeError,
+    )
+    // Exactly 256 is allowed — boundary sanity.
+    const atLimit = tooManyFrames.slice(0, 256)
+    expect(() => stack.runWithFrames(atLimit, () => undefined)).not.toThrow()
+  })
+
+  test('snapshot returns a frozen array that rejects mutation in strict mode', () => {
+    const stack = new DescribeStack()
+    stack.run('outer', () => {
+      const snap = stack.snapshot
+      expect(Object.isFrozen(snap)).toBe(true)
+      // Test files are ESM (strict) — mutating a frozen array throws TypeError.
+      expect(() => {
+        ;(snap as string[]).push('leaked')
+      }).toThrow(TypeError)
+      // Stack state stayed clean.
+      expect(stack.depth).toBe(1)
+      expect([...stack.snapshot]).toEqual(['outer'])
     })
   })
 })


### PR DESCRIPTION
Closes #33.

## Summary
Adds five regression tests covering the \`MAX_DESCRIBE_DEPTH = 256\` guard that landed in #19 without coverage:

1. **Constant sanity** — asserts \`MAX_DESCRIBE_DEPTH === 256\`. Any change to the constant fails this test so the guard becomes a behavioral contract rather than an implementation detail.
2. **256 deep succeeds** — recurses 256 \`run()\` calls, verifies the observed \`stack.depth\` reaches 256, and that every frame pops on return.
3. **257th throws RangeError** — recurses one level past the limit and asserts the correct exception type.
4. **runWithFrames caps at 256** — rejects \`Array(257)\` with \`RangeError\`, accepts exactly 256 as a boundary check.
5. **snapshot is frozen** — \`Object.isFrozen(snap)\` is true and \`.push()\` throws \`TypeError\` in ESM strict mode.

Values are **hardcoded to 256/257** rather than referencing the imported constant — this is intentional. The issue's acceptance criteria explicitly call for tests that fail if \`MAX_DESCRIBE_DEPTH\` is reduced or removed. Dynamic references would silently track any change.

## Test plan
- [x] \`bun test\` — 306 pass / 0 fail (was 301; +5 new)
- [x] \`bun run typecheck\` clean
- [x] \`bun run check\` (biome) clean
- [x] Manually reduced \`MAX_DESCRIBE_DEPTH\` to 10 and confirmed the constant-sanity test fails as expected, then restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)