### PR TITLE
feat(stores): versioned schema migrations for sqlite + turso

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,15 @@ export {
   type LogLevel,
   resolveLogLevel,
 } from './log'
+export {
+  CREATE_SCHEMA_VERSION_TABLE,
+  detectBaselineVersion,
+  pendingMigrations,
+  SCHEMA_VERSION_TABLE,
+  type SchemaInspector,
+  SQLITE_MIGRATIONS,
+  type SqliteMigration,
+} from './migrations'
 export { mapRowToPattern, type PatternRow } from './pattern-mapper'
 export {
   definePlugin,

--- a/packages/core/src/migrations.test.ts
+++ b/packages/core/src/migrations.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  detectBaselineVersion,
+  pendingMigrations,
+  type SchemaInspector,
+  SQLITE_MIGRATIONS,
+  type SqliteMigration,
+} from './migrations'
+
+/** Build a stub inspector from a table->columns map. */
+function makeInspector(
+  tables: Record<string, readonly string[]>,
+): SchemaInspector {
+  return {
+    tableExists: (name) => Object.hasOwn(tables, name),
+    columnExists: (table, column) =>
+      Object.hasOwn(tables, table) && tables[table]?.includes(column) === true,
+  }
+}
+
+describe('SQLITE_MIGRATIONS', () => {
+  test('versions are contiguous starting at 1', () => {
+    for (const [index, migration] of SQLITE_MIGRATIONS.entries()) {
+      expect(migration.version).toBe(index + 1)
+    }
+  })
+
+  test('every migration has at least one up statement', () => {
+    for (const migration of SQLITE_MIGRATIONS) {
+      expect(migration.up.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('every migration has a non-empty description', () => {
+    for (const migration of SQLITE_MIGRATIONS) {
+      expect(migration.description.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('detectBaselineVersion', () => {
+  test('returns 0 for a fresh database (no runs table)', () => {
+    const inspect = makeInspector({})
+    expect(detectBaselineVersion(SQLITE_MIGRATIONS, inspect)).toBe(0)
+  })
+
+  test('returns 1 for a database with only the base schema', () => {
+    const inspect = makeInspector({
+      runs: ['run_id', 'started_at'],
+      failures: ['id'],
+    })
+    expect(detectBaselineVersion(SQLITE_MIGRATIONS, inspect)).toBe(1)
+  })
+
+  test('returns 5 when test_args is present but project is not', () => {
+    const inspect = makeInspector({
+      runs: [
+        'run_id',
+        'started_at',
+        'passed_tests',
+        'errors_between_tests',
+        'runtime_version',
+        'test_args',
+      ],
+      failures: ['id'],
+    })
+    expect(detectBaselineVersion(SQLITE_MIGRATIONS, inspect)).toBe(5)
+  })
+
+  test('returns the max version when every probe passes', () => {
+    const inspect = makeInspector({
+      runs: [
+        'run_id',
+        'started_at',
+        'passed_tests',
+        'errors_between_tests',
+        'runtime_version',
+        'test_args',
+        'project',
+      ],
+      failures: ['id'],
+    })
+    expect(detectBaselineVersion(SQLITE_MIGRATIONS, inspect)).toBe(
+      SQLITE_MIGRATIONS.length,
+    )
+  })
+
+  test('stops at the first probe that fails — does not resume downstream', () => {
+    // Columns present AFTER the gap should not advance the baseline:
+    // project exists but passed_tests is missing. Baseline must be 1
+    // because v2's probe fails and we never resume.
+    const inspect = makeInspector({
+      runs: ['run_id', 'started_at', 'project'],
+      failures: ['id'],
+    })
+    expect(detectBaselineVersion(SQLITE_MIGRATIONS, inspect)).toBe(1)
+  })
+})
+
+describe('pendingMigrations', () => {
+  test('returns all migrations when current version is 0', () => {
+    const result = pendingMigrations(SQLITE_MIGRATIONS, 0)
+    expect(result.length).toBe(SQLITE_MIGRATIONS.length)
+  })
+
+  test('returns none when current version is at or above max', () => {
+    const max = SQLITE_MIGRATIONS.length
+    expect(pendingMigrations(SQLITE_MIGRATIONS, max).length).toBe(0)
+    expect(pendingMigrations(SQLITE_MIGRATIONS, max + 10).length).toBe(0)
+  })
+
+  test('returns only later migrations when partially applied', () => {
+    const result = pendingMigrations(SQLITE_MIGRATIONS, 3)
+    expect(result.map((migration) => migration.version)).toEqual([4, 5, 6])
+  })
+})
+
+describe('custom migration arrays', () => {
+  // Sanity check: the helpers work on any migration list, not just the
+  // built-in one. Guards against accidentally hardcoding the global.
+  const synthetic: readonly SqliteMigration[] = [
+    {
+      version: 1,
+      description: 'create widgets',
+      up: ['CREATE TABLE widgets (id INTEGER)'],
+      probe: (inspect) => inspect.tableExists('widgets'),
+    },
+    {
+      version: 2,
+      description: 'add widgets.color',
+      up: ['ALTER TABLE widgets ADD COLUMN color TEXT'],
+      probe: (inspect) => inspect.columnExists('widgets', 'color'),
+    },
+  ]
+
+  test('detects baseline on a custom list', () => {
+    const inspect = makeInspector({ widgets: ['id'] })
+    expect(detectBaselineVersion(synthetic, inspect)).toBe(1)
+  })
+
+  test('filters pending on a custom list', () => {
+    expect(pendingMigrations(synthetic, 1).map((m) => m.version)).toEqual([2])
+  })
+})

--- a/packages/core/src/migrations.ts
+++ b/packages/core/src/migrations.ts
@@ -1,0 +1,144 @@
+/**
+ * Versioned-migration support shared by the SQLite-dialect stores
+ * (store-sqlite and store-turso). Migrations are a monotonic array of
+ * `{ version, up, probe }` records; adapters provide thin runners that
+ * track applied versions in a `schema_version` table and apply pending
+ * migrations transactionally.
+ *
+ * Design notes:
+ * - The migration list is deliberately a flat array — version is the
+ *   array index + 1, and new migrations append. This keeps version
+ *   numbers contiguous and makes review easy.
+ * - `probe` lets the runner seed a baseline for pre-existing databases
+ *   that were created before we started recording versions: we walk the
+ *   list in order and consider a migration "already applied" as long as
+ *   its probe still passes on the live schema.
+ * - The list is SQLite-dialect; postgres/supabase are out of scope (they
+ *   use `CREATE TABLE IF NOT EXISTS` / manual Dashboard setup).
+ */
+
+/** Introspection callbacks the migration probes run against the live DB. */
+export interface SchemaInspector {
+  tableExists: (name: string) => boolean
+  columnExists: (table: string, column: string) => boolean
+}
+
+/** Single versioned migration. `up` statements run in order, in one transaction. */
+export interface SqliteMigration {
+  version: number
+  description: string
+  up: readonly string[]
+  /**
+   * Returns true when the migration's effect is already visible on the live
+   * schema. Used once, only for databases with no `schema_version` rows yet,
+   * to infer a starting baseline without re-running DDL that would fail.
+   */
+  probe: (inspect: SchemaInspector) => boolean
+}
+
+/** Name of the table every adapter creates to record applied migrations. */
+export const SCHEMA_VERSION_TABLE = 'schema_version'
+
+/** DDL for the bookkeeping table. Adapters run this before anything else. */
+export const CREATE_SCHEMA_VERSION_TABLE = `CREATE TABLE IF NOT EXISTS ${SCHEMA_VERSION_TABLE} (
+  version     INTEGER PRIMARY KEY,
+  applied_at  TEXT NOT NULL
+)`
+
+/**
+ * Ordered migration list for SQLite-dialect adapters. Adding a migration
+ * means appending a new entry with `version = previous + 1`; never reorder,
+ * rewrite, or delete entries once they've shipped.
+ */
+export const SQLITE_MIGRATIONS: readonly SqliteMigration[] = [
+  {
+    version: 1,
+    description: 'Create base runs + failures schema with indexes',
+    up: [
+      `CREATE TABLE IF NOT EXISTS runs (
+        run_id         TEXT PRIMARY KEY,
+        started_at     TEXT NOT NULL,
+        ended_at       TEXT,
+        duration_ms    INTEGER,
+        status         TEXT,
+        total_tests    INTEGER,
+        failed_tests   INTEGER,
+        git_sha        TEXT,
+        git_dirty      INTEGER
+      )`,
+      `CREATE TABLE IF NOT EXISTS failures (
+        id             INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id         TEXT NOT NULL REFERENCES runs(run_id),
+        test_file      TEXT NOT NULL,
+        test_name      TEXT NOT NULL,
+        failure_kind   TEXT NOT NULL,
+        error_message  TEXT,
+        error_stack    TEXT,
+        duration_ms    INTEGER,
+        failed_at      TEXT NOT NULL
+      )`,
+      'CREATE INDEX IF NOT EXISTS idx_failures_test      ON failures(test_file, test_name)',
+      'CREATE INDEX IF NOT EXISTS idx_failures_run       ON failures(run_id)',
+      'CREATE INDEX IF NOT EXISTS idx_failures_failed_at ON failures(failed_at)',
+      'CREATE INDEX IF NOT EXISTS idx_runs_status        ON runs(ended_at, failed_tests)',
+    ],
+    probe: (inspect) => inspect.tableExists('runs'),
+  },
+  {
+    version: 2,
+    description: 'Add runs.passed_tests',
+    up: ['ALTER TABLE runs ADD COLUMN passed_tests INTEGER'],
+    probe: (inspect) => inspect.columnExists('runs', 'passed_tests'),
+  },
+  {
+    version: 3,
+    description: 'Add runs.errors_between_tests',
+    up: ['ALTER TABLE runs ADD COLUMN errors_between_tests INTEGER'],
+    probe: (inspect) => inspect.columnExists('runs', 'errors_between_tests'),
+  },
+  {
+    version: 4,
+    description: 'Add runs.runtime_version',
+    up: ['ALTER TABLE runs ADD COLUMN runtime_version TEXT'],
+    probe: (inspect) => inspect.columnExists('runs', 'runtime_version'),
+  },
+  {
+    version: 5,
+    description: 'Add runs.test_args',
+    up: ['ALTER TABLE runs ADD COLUMN test_args TEXT'],
+    probe: (inspect) => inspect.columnExists('runs', 'test_args'),
+  },
+  {
+    version: 6,
+    description: 'Add runs.project',
+    up: ['ALTER TABLE runs ADD COLUMN project TEXT'],
+    probe: (inspect) => inspect.columnExists('runs', 'project'),
+  },
+]
+
+/**
+ * Walk `migrations` in version order and return the highest contiguous
+ * version whose `probe` passes against the live schema. Used to seed a
+ * baseline for databases that existed before we introduced
+ * `schema_version`. Returns `0` when no migrations have been applied yet
+ * (fresh database).
+ */
+export function detectBaselineVersion(
+  migrations: readonly SqliteMigration[],
+  inspect: SchemaInspector,
+): number {
+  let baseline = 0
+  for (const migration of migrations) {
+    if (!migration.probe(inspect)) break
+    baseline = migration.version
+  }
+  return baseline
+}
+
+/** Filter to migrations that still need to run given the current applied version. */
+export function pendingMigrations(
+  migrations: readonly SqliteMigration[],
+  currentVersion: number,
+): readonly SqliteMigration[] {
+  return migrations.filter((migration) => migration.version > currentVersion)
+}

--- a/packages/store-sqlite/src/index.test.ts
+++ b/packages/store-sqlite/src/index.test.ts
@@ -1,4 +1,6 @@
+import { Database } from 'bun:sqlite'
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { SQLITE_MIGRATIONS } from '@flaky-tests/core'
 import {
   daysAgo,
   makeFailure,
@@ -28,6 +30,81 @@ describe('SqliteStore — adapter-specific', () => {
   test('insertRun with a duplicate runId throws', async () => {
     await store.insertRun(makeRun('run-dup'))
     expect(() => store.insertRun(makeRun('run-dup'))).toThrow()
+  })
+})
+
+describe('SqliteStore — schema_version migrations', () => {
+  test('fresh DB records every migration in schema_version', () => {
+    const fresh = new SqliteStore({ dbPath: ':memory:' })
+    const applied = fresh.getAppliedMigrations()
+    expect(applied.map((row) => row.version)).toEqual(
+      SQLITE_MIGRATIONS.map((migration) => migration.version),
+    )
+    for (const row of applied) {
+      expect(row.applied_at.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('migrate() is idempotent — a second call adds no new rows', async () => {
+    const initial = store.getAppliedMigrations()
+    await store.migrate()
+    const after = store.getAppliedMigrations()
+    expect(after).toEqual(initial)
+  })
+
+  test('pre-existing partial DB (has some columns, missing project) upgrades cleanly', async () => {
+    // Simulate a v5 database: all columns up to `test_args`, but no `project`
+    // and no schema_version table. This mirrors a real user upgrading from
+    // before version tracking landed.
+    const db = new Database(':memory:')
+    db.exec(`
+      CREATE TABLE runs (
+        run_id               TEXT PRIMARY KEY,
+        started_at           TEXT NOT NULL,
+        ended_at             TEXT,
+        duration_ms          INTEGER,
+        status               TEXT,
+        total_tests          INTEGER,
+        passed_tests         INTEGER,
+        failed_tests         INTEGER,
+        errors_between_tests INTEGER,
+        git_sha              TEXT,
+        git_dirty            INTEGER,
+        runtime_version      TEXT,
+        test_args            TEXT
+      );
+      CREATE TABLE failures (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id TEXT NOT NULL REFERENCES runs(run_id),
+        test_file TEXT NOT NULL, test_name TEXT NOT NULL,
+        failure_kind TEXT NOT NULL,
+        error_message TEXT, error_stack TEXT,
+        duration_ms INTEGER, failed_at TEXT NOT NULL
+      );
+    `)
+    const tempPath = `/tmp/flaky-tests-migrate-${Date.now()}.db`
+    db.serialize()
+    // Write the simulated legacy DB to disk so we can open it with SqliteStore.
+    // bun:sqlite :memory: has no path we can hand off, so we seed the file directly.
+    const fs = await import('node:fs')
+    fs.writeFileSync(tempPath, db.serialize())
+    db.close()
+
+    const upgraded = new SqliteStore({ dbPath: tempPath })
+    const applied = upgraded.getAppliedMigrations()
+    // Versions 1..5 should be seeded (baseline), version 6 applied for real.
+    expect(applied.map((row) => row.version)).toEqual([1, 2, 3, 4, 5, 6])
+
+    // And the project column should now exist.
+    const info = upgraded
+      .getDb()
+      .query<{ name: string }, []>('PRAGMA table_info(runs)')
+      .all()
+      .map((row) => row.name)
+    expect(info).toContain('project')
+
+    await upgraded.close()
+    fs.unlinkSync(tempPath)
   })
 })
 

--- a/packages/store-sqlite/src/index.ts
+++ b/packages/store-sqlite/src/index.ts
@@ -2,10 +2,12 @@ import { Database } from 'bun:sqlite'
 import { mkdirSync } from 'node:fs'
 import {
   type Config,
+  CREATE_SCHEMA_VERSION_TABLE,
   createLogger,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   definePlugin,
+  detectBaselineVersion,
   type FlakyPattern,
   flakyPatternSchema,
   type GetNewPatternsOptions,
@@ -21,8 +23,13 @@ import {
   mapRowToPattern,
   parse,
   parseArray,
+  pendingMigrations,
   type RecentRun,
   type RunStatus,
+  SCHEMA_VERSION_TABLE,
+  type SchemaInspector,
+  SQLITE_MIGRATIONS,
+  type SqliteMigration,
   type UpdateRunInput,
   updateRunInputSchema,
 } from '@flaky-tests/core'
@@ -40,41 +47,43 @@ export type SqliteStoreOptions = typeof sqliteStoreOptionsSchema.infer
 
 const DEFAULT_DB_PATH = 'node_modules/.cache/flaky-tests/failures.db'
 
-const SCHEMA = `
-CREATE TABLE IF NOT EXISTS runs (
-  run_id                TEXT PRIMARY KEY,
-  project               TEXT,
-  started_at            TEXT NOT NULL,
-  ended_at              TEXT,
-  duration_ms           INTEGER,
-  status                TEXT,
-  total_tests           INTEGER,
-  passed_tests          INTEGER,
-  failed_tests          INTEGER,
-  errors_between_tests  INTEGER,
-  git_sha               TEXT,
-  git_dirty             INTEGER,
-  runtime_version       TEXT,
-  test_args             TEXT
-);
+/** Row shape in the bookkeeping `schema_version` table. */
+interface SchemaVersionRow {
+  version: number
+  applied_at: string
+}
 
-CREATE TABLE IF NOT EXISTS failures (
-  id             INTEGER PRIMARY KEY AUTOINCREMENT,
-  run_id         TEXT NOT NULL REFERENCES runs(run_id),
-  test_file      TEXT NOT NULL,
-  test_name      TEXT NOT NULL,
-  failure_kind   TEXT NOT NULL,
-  error_message  TEXT,
-  error_stack    TEXT,
-  duration_ms    INTEGER,
-  failed_at      TEXT NOT NULL
-);
+/** Row shape returned by SQLite's `PRAGMA table_info(...)`. */
+interface PragmaTableInfoRow {
+  cid: number
+  name: string
+  type: string
+  notnull: number
+  dflt_value: string | null
+  pk: number
+}
 
-CREATE INDEX IF NOT EXISTS idx_failures_test      ON failures(test_file, test_name);
-CREATE INDEX IF NOT EXISTS idx_failures_run       ON failures(run_id);
-CREATE INDEX IF NOT EXISTS idx_failures_failed_at ON failures(failed_at);
-CREATE INDEX IF NOT EXISTS idx_runs_status        ON runs(ended_at, failed_tests);
-`
+/** Build a {@link SchemaInspector} backed by SQLite `PRAGMA` introspection. */
+function makeSqliteInspector(db: Database): SchemaInspector {
+  return {
+    tableExists: (name) => {
+      const row = db
+        .query<{ name: string }, [string]>(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name = ? LIMIT 1",
+        )
+        .get(name)
+      return row !== null
+    },
+    columnExists: (table, column) => {
+      // PRAGMA doesn't accept bind parameters; `table` is a trusted constant
+      // from our migration list, not user input, so interpolation is safe.
+      const rows = db
+        .query<PragmaTableInfoRow, []>(`PRAGMA table_info(${table})`)
+        .all()
+      return rows.some((row) => row.name === column)
+    },
+  }
+}
 
 /** Create the parent directory for the DB file if missing so SQLite can open it. */
 function ensureDirectory(dbPath: string): void {
@@ -110,31 +119,76 @@ export class SqliteStore implements IStore {
     ensureDirectory(dbPath)
     this.db = new Database(dbPath, { create: true })
     this.db.exec('PRAGMA journal_mode = WAL')
-    this.db.exec(SCHEMA)
     // `migrate` is sync under bun:sqlite (only exec calls) but declared async
     // by the IStore contract; constructors can't await so we fire-and-forget.
     void this.migrate()
   }
 
   /**
-   * Create tables and run idempotent column additions for older databases.
-   * Called automatically in the constructor — safe to call again.
+   * Bring the database to the current schema version by applying pending
+   * migrations from {@link SQLITE_MIGRATIONS}. Safe to call on every startup:
+   * tracks applied versions in the `schema_version` table, and for databases
+   * created before versioning existed, seeds a baseline by probing which
+   * columns already exist — so we never re-run DDL that would fail.
    */
   async migrate(): Promise<void> {
-    const migrations = [
-      'ALTER TABLE runs ADD COLUMN passed_tests INTEGER',
-      'ALTER TABLE runs ADD COLUMN errors_between_tests INTEGER',
-      'ALTER TABLE runs ADD COLUMN runtime_version TEXT',
-      'ALTER TABLE runs ADD COLUMN test_args TEXT',
-      'ALTER TABLE runs ADD COLUMN project TEXT',
-    ]
-    for (const stmt of migrations) {
-      try {
-        this.db.exec(stmt)
-      } catch {
-        // Column already present.
-      }
+    this.db.exec(CREATE_SCHEMA_VERSION_TABLE)
+    const current = this.getCurrentVersion()
+    const baseline =
+      current > 0
+        ? current
+        : detectBaselineVersion(SQLITE_MIGRATIONS, makeSqliteInspector(this.db))
+    if (baseline > current) {
+      // Seed rows for migrations whose effects already live in the schema —
+      // without running their DDL again.
+      const now = new Date().toISOString()
+      const seed = this.db.prepare(
+        `INSERT INTO ${SCHEMA_VERSION_TABLE} (version, applied_at) VALUES (?, ?)`,
+      )
+      this.db.transaction(() => {
+        for (let version = current + 1; version <= baseline; version++) {
+          seed.run(version, now)
+        }
+      })()
     }
+    for (const migration of pendingMigrations(SQLITE_MIGRATIONS, baseline)) {
+      this.applyMigration(migration)
+    }
+  }
+
+  private getCurrentVersion(): number {
+    const row = this.db
+      .query<{ version: number | null }, []>(
+        `SELECT MAX(version) AS version FROM ${SCHEMA_VERSION_TABLE}`,
+      )
+      .get()
+    return row?.version ?? 0
+  }
+
+  /** Apply one migration's `up` statements and record the version atomically. */
+  private applyMigration(migration: SqliteMigration): void {
+    const now = new Date().toISOString()
+    this.db.transaction(() => {
+      for (const statement of migration.up) {
+        this.db.exec(statement)
+      }
+      this.db.run(
+        `INSERT INTO ${SCHEMA_VERSION_TABLE} (version, applied_at) VALUES (?, ?)`,
+        [migration.version, now],
+      )
+    })()
+    log.debug(
+      `applied migration v${migration.version}: ${migration.description}`,
+    )
+  }
+
+  /** Expose the applied-migration ledger for tooling/tests. */
+  getAppliedMigrations(): SchemaVersionRow[] {
+    return this.db
+      .query<SchemaVersionRow, []>(
+        `SELECT version, applied_at FROM ${SCHEMA_VERSION_TABLE} ORDER BY version ASC`,
+      )
+      .all()
   }
 
   /**

--- a/packages/store-turso/src/index.test.ts
+++ b/packages/store-turso/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { StoreError } from '@flaky-tests/core'
+import { SQLITE_MIGRATIONS, StoreError } from '@flaky-tests/core'
 import { TursoStore } from './index'
 
 // Unit-tier: uses `file::memory:` so nothing touches a remote libSQL service.
@@ -39,6 +39,34 @@ describe('TursoStore — fresh-database path', () => {
       })
       const patterns = await store.getNewPatterns()
       expect(patterns).toEqual([])
+    } finally {
+      await store.close()
+    }
+  })
+})
+
+describe('TursoStore — schema_version migrations', () => {
+  test('fresh DB records every migration in schema_version', async () => {
+    const store = new TursoStore({ url: 'file::memory:' })
+    try {
+      await store.migrate()
+      const applied = await store.getAppliedMigrations()
+      expect(applied.map((row) => row.version)).toEqual(
+        SQLITE_MIGRATIONS.map((migration) => migration.version),
+      )
+    } finally {
+      await store.close()
+    }
+  })
+
+  test('migrate() is idempotent — a second call adds no new rows', async () => {
+    const store = new TursoStore({ url: 'file::memory:' })
+    try {
+      await store.migrate()
+      const first = await store.getAppliedMigrations()
+      await store.migrate()
+      const second = await store.getAppliedMigrations()
+      expect(second).toEqual(first)
     } finally {
       await store.close()
     }

--- a/packages/store-turso/src/index.ts
+++ b/packages/store-turso/src/index.ts
@@ -1,9 +1,11 @@
 import {
   type Config,
+  CREATE_SCHEMA_VERSION_TABLE,
   createLogger,
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   definePlugin,
+  detectBaselineVersion,
   extractMessage,
   type FlakyPattern,
   flakyPatternSchema,
@@ -21,9 +23,14 @@ import {
   type PatternRow,
   parse,
   parseArray,
+  pendingMigrations,
   type RecentRun,
   type RunStatus,
   raceAbort,
+  SCHEMA_VERSION_TABLE,
+  type SchemaInspector,
+  SQLITE_MIGRATIONS,
+  type SqliteMigration,
   StoreError,
   type UpdateRunInput,
   updateRunInputSchema,
@@ -44,42 +51,11 @@ export const tursoStoreOptionsSchema = type({
 /** Inferred options type for {@link TursoStore}: libSQL URL plus optional HTTP auth token. */
 export type TursoStoreOptions = typeof tursoStoreOptionsSchema.infer
 
-// Schema is identical to store-sqlite — Turso is SQLite-compatible.
-const SCHEMA = `
-CREATE TABLE IF NOT EXISTS runs (
-  run_id                TEXT PRIMARY KEY,
-  project               TEXT,
-  started_at            TEXT NOT NULL,
-  ended_at              TEXT,
-  duration_ms           INTEGER,
-  status                TEXT,
-  total_tests           INTEGER,
-  passed_tests          INTEGER,
-  failed_tests          INTEGER,
-  errors_between_tests  INTEGER,
-  git_sha               TEXT,
-  git_dirty             INTEGER,
-  runtime_version       TEXT,
-  test_args             TEXT
-);
-
-CREATE TABLE IF NOT EXISTS failures (
-  id             INTEGER PRIMARY KEY AUTOINCREMENT,
-  run_id         TEXT NOT NULL REFERENCES runs(run_id),
-  test_file      TEXT NOT NULL,
-  test_name      TEXT NOT NULL,
-  failure_kind   TEXT NOT NULL,
-  error_message  TEXT,
-  error_stack    TEXT,
-  duration_ms    INTEGER,
-  failed_at      TEXT NOT NULL
-);
-
-CREATE INDEX IF NOT EXISTS idx_failures_test      ON failures(test_file, test_name);
-CREATE INDEX IF NOT EXISTS idx_failures_run       ON failures(run_id);
-CREATE INDEX IF NOT EXISTS idx_failures_failed_at ON failures(failed_at);
-CREATE INDEX IF NOT EXISTS idx_runs_status        ON runs(ended_at, failed_tests);
-`
+/** Shape of a row in the bookkeeping `schema_version` table. */
+interface SchemaVersionRow {
+  version: number
+  applied_at: string
+}
 
 /**
  * `IStore` implementation targeting libSQL/Turso over HTTP with bearer-token auth.
@@ -114,29 +90,113 @@ export class TursoStore implements IStore {
     }
   }
 
-  /** Create tables if they don't exist. Call once before first use. */
+  /**
+   * Bring the remote libSQL database to the current schema version by
+   * applying pending migrations from {@link SQLITE_MIGRATIONS}. Tracks
+   * applied versions in a `schema_version` table and seeds a baseline for
+   * databases created before versioning landed by probing the live schema.
+   */
   async migrate(): Promise<void> {
     await this.wrap('migrate', async () => {
-      for (const stmt of SCHEMA.trim()
-        .split(';')
-        .filter((s) => s.trim())) {
-        await this.client.execute(stmt)
-      }
-      // Idempotent column additions for older DBs
-      const migrations = [
-        'ALTER TABLE runs ADD COLUMN passed_tests INTEGER',
-        'ALTER TABLE runs ADD COLUMN errors_between_tests INTEGER',
-        'ALTER TABLE runs ADD COLUMN runtime_version TEXT',
-        'ALTER TABLE runs ADD COLUMN test_args TEXT',
-        'ALTER TABLE runs ADD COLUMN project TEXT',
-      ]
-      for (const stmt of migrations) {
-        try {
-          await this.client.execute(stmt)
-        } catch {
-          // Column already present — swallowed intentionally inside the
-          // wrap boundary; migrate() itself still reports other failures.
+      await this.client.execute(CREATE_SCHEMA_VERSION_TABLE)
+      const current = await this.getCurrentVersion()
+      const inspector = await this.buildSchemaInspector()
+      const baseline =
+        current > 0
+          ? current
+          : detectBaselineVersion(SQLITE_MIGRATIONS, inspector)
+      if (baseline > current) {
+        const now = new Date().toISOString()
+        const seedStatements = []
+        for (let version = current + 1; version <= baseline; version++) {
+          seedStatements.push({
+            sql: `INSERT INTO ${SCHEMA_VERSION_TABLE} (version, applied_at) VALUES (?, ?)`,
+            args: [version, now] as InArgs,
+          })
         }
+        if (seedStatements.length > 0) {
+          await this.client.batch(seedStatements, 'write')
+        }
+      }
+      for (const migration of pendingMigrations(SQLITE_MIGRATIONS, baseline)) {
+        await this.applyMigration(migration)
+      }
+    })
+  }
+
+  private async getCurrentVersion(): Promise<number> {
+    const result = await this.client.execute(
+      `SELECT MAX(version) AS version FROM ${SCHEMA_VERSION_TABLE}`,
+    )
+    const row = result.rows[0] as unknown as
+      | { version: number | bigint | null }
+      | undefined
+    const raw = row?.version
+    if (raw == null) return 0
+    return typeof raw === 'bigint' ? Number(raw) : raw
+  }
+
+  /**
+   * Introspect the live schema via SQLite PRAGMAs so migration probes can
+   * detect which versions are already materialized on a pre-versioning DB.
+   */
+  private async buildSchemaInspector(): Promise<SchemaInspector> {
+    const tableNames = new Set<string>()
+    const columnsByTable = new Map<string, Set<string>>()
+    const tables = await this.client.execute(
+      "SELECT name FROM sqlite_master WHERE type = 'table'",
+    )
+    for (const row of tables.rows) {
+      const { name } = row as unknown as { name: string }
+      if (typeof name === 'string' && name.length > 0) tableNames.add(name)
+    }
+    for (const tableName of tableNames) {
+      // PRAGMA doesn't accept bind parameters; table names come from our
+      // own migration list probes (constants), not user input.
+      const info = await this.client.execute(`PRAGMA table_info(${tableName})`)
+      const columns = new Set<string>()
+      for (const row of info.rows) {
+        const { name } = row as unknown as { name: string }
+        if (typeof name === 'string') columns.add(name)
+      }
+      columnsByTable.set(tableName, columns)
+    }
+    return {
+      tableExists: (name) => tableNames.has(name),
+      columnExists: (table, column) =>
+        columnsByTable.get(table)?.has(column) === true,
+    }
+  }
+
+  /** Apply one migration's `up` statements + schema_version row atomically. */
+  private async applyMigration(migration: SqliteMigration): Promise<void> {
+    const now = new Date().toISOString()
+    const statements = [
+      ...migration.up.map((sql) => ({ sql, args: [] as InArgs })),
+      {
+        sql: `INSERT INTO ${SCHEMA_VERSION_TABLE} (version, applied_at) VALUES (?, ?)`,
+        args: [migration.version, now] as InArgs,
+      },
+    ]
+    await this.client.batch(statements, 'write')
+    log.debug(
+      `applied migration v${migration.version}: ${migration.description}`,
+    )
+  }
+
+  /** Expose the applied-migration ledger for tooling/tests. */
+  async getAppliedMigrations(): Promise<SchemaVersionRow[]> {
+    const result = await this.client.execute(
+      `SELECT version, applied_at FROM ${SCHEMA_VERSION_TABLE} ORDER BY version ASC`,
+    )
+    return result.rows.map((row) => {
+      const r = row as unknown as {
+        version: number | bigint
+        applied_at: string
+      }
+      return {
+        version: typeof r.version === 'bigint' ? Number(r.version) : r.version,
+        applied_at: r.applied_at,
       }
     })
   }


### PR DESCRIPTION
## Summary

- Shared `SQLITE_MIGRATIONS` list + helpers (`detectBaselineVersion`, `pendingMigrations`) in `@flaky-tests/core`.
- Both SQLite-dialect adapters (store-sqlite, store-turso) track applied versions in `schema_version(version, applied_at)` and apply only pending migrations.
- Atomic per-migration: sqlite wraps each in a transaction, turso uses libsql `batch`.
- Pre-existing databases with the current schema but no `schema_version` row are detected via introspection probes and get a baseline seeded — no re-running DDL that would fail.

Closes #32

## Design

Each migration is `{ version, description, up: string[], probe }`. Versions are contiguous and append-only:
1. Create base runs + failures schema with indexes
2. Add `runs.passed_tests`
3. Add `runs.errors_between_tests`
4. Add `runs.runtime_version`
5. Add `runs.test_args`
6. Add `runs.project`

`probe(inspector)` returns true when the migration's effect is already visible on the live schema (table or column exists). The runner walks probes in order from v1 and stops at the first failure — whatever prefix passed becomes the seeded baseline. Everything strictly greater runs for real.

## Out of scope

Postgres and supabase keep their existing strategies (CREATE TABLE IF NOT EXISTS / manual Dashboard setup) per the issue note.

## Test plan

- [x] `bun run typecheck` — 8 configs clean
- [x] `bun run check` — biome clean
- [x] `bun test` — 319 pass (13 new core migration tests + 3 new sqlite adapter tests + 2 new turso adapter tests)
- [x] `INTEGRATION=1 bun test packages/store-turso` — 31 pass against in-memory libSQL
- [x] Pre-existing partial DB test: seed a v5-shape SQLite file on disk (runs table has test_args but no project), open with SqliteStore, verify applied migrations are 1..6 and `project` column is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)