### PR TITLE
docs(stores): add @throws tags to every public IStore method (closes #58)

### DIFF
--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -107,7 +107,13 @@ export class PostgresStore implements IStore {
   private failuresTable: string
   private retryOptions: RetryOptions
 
-  /** Accepts either a full `connectionString` or individual host/port/credentials fields. */
+  /**
+   * Accepts either a full `connectionString` or individual host/port/credentials fields.
+   *
+   * @throws {@link ValidationError} when `options` fails schema validation.
+   * @throws `Error` when `tablePrefix` contains characters outside
+   *   `[a-z0-9_]` (via `validateTablePrefix`).
+   */
   constructor(options: PostgresStoreOptions = {}) {
     const validated = parse(postgresStoreOptionsSchema, options)
     const prefix = validated.tablePrefix ?? 'flaky_test'
@@ -150,7 +156,12 @@ export class PostgresStore implements IStore {
     }
   }
 
-  /** Create tables and run idempotent schema migrations. Safe to call on every startup. */
+  /**
+   * Create tables and run idempotent schema migrations. Safe to call on every startup.
+   *
+   * @throws {@link StoreError} when a DDL statement fails at the postgres
+   *   driver level (connection refused, insufficient privileges, etc.).
+   */
   async migrate(): Promise<void> {
     const runs = this.runsTable
     const failures = this.failuresTable
@@ -210,7 +221,13 @@ export class PostgresStore implements IStore {
     })
   }
 
-  /** Insert a new test run record. Must be called before any failures reference this run. */
+  /**
+   * Insert a new test run record. Must be called before any failures reference this run.
+   *
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link StoreError} when the postgres driver rejects the insert
+   *   (network, auth, duplicate `run_id`, etc.).
+   */
   async insertRun(input: InsertRunInput): Promise<void> {
     parse(insertRunInputSchema, input)
     const runs = this.runsTable
@@ -226,7 +243,12 @@ export class PostgresStore implements IStore {
     })
   }
 
-  /** Update a run with final results (duration, status, test counts) after it completes. */
+  /**
+   * Update a run with final results (duration, status, test counts) after it completes.
+   *
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link StoreError} when the postgres driver rejects the update.
+   */
   async updateRun(runId: string, input: UpdateRunInput): Promise<void> {
     parse(updateRunInputSchema, input)
     const runs = this.runsTable
@@ -245,7 +267,12 @@ export class PostgresStore implements IStore {
     })
   }
 
-  /** Record a single test failure associated with an existing run. */
+  /**
+   * Record a single test failure associated with an existing run.
+   *
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link StoreError} when the postgres driver rejects the insert.
+   */
   async insertFailure(input: InsertFailureInput): Promise<void> {
     parse(insertFailureInputSchema, input)
     const failures = this.failuresTable
@@ -264,7 +291,14 @@ export class PostgresStore implements IStore {
     })
   }
 
-  /** Insert multiple failures in a single Postgres transaction. */
+  /**
+   * Insert multiple failures in a single Postgres transaction.
+   *
+   * @throws {@link ValidationError} when any entry in `inputs` fails schema
+   *   validation — the transaction rolls back and nothing is written.
+   * @throws {@link StoreError} when the postgres driver rejects the
+   *   transaction.
+   */
   async insertFailures(inputs: readonly InsertFailureInput[]): Promise<void> {
     if (inputs.length === 0) return
     const failures = this.failuresTable
@@ -292,6 +326,13 @@ export class PostgresStore implements IStore {
    * Detect newly-flaky tests by comparing a recent window to a prior window of equal length.
    * Returns tests that failed >= `threshold` times in the recent window but zero times
    * in the prior window, filtering out runs with 10+ failures (likely infrastructure issues).
+   *
+   * @throws {@link ValidationError} when `options` fails schema validation.
+   * @throws `DOMException` with `name === 'AbortError'` when
+   *   `options.signal` aborts — via `throwIfAborted()` at entry or the
+   *   `cancelOnAbort` wrapper, which also fires the pending query's
+   *   server-side `cancel()` so the DB releases the connection.
+   * @throws {@link StoreError} when the postgres driver rejects the query.
    */
   async getNewPatterns(
     options: GetNewPatternsOptions = {},
@@ -359,7 +400,14 @@ export class PostgresStore implements IStore {
     return patterns
   }
 
-  /** Return the N most recent runs ordered by `startedAt` DESC, filtered by project. */
+  /**
+   * Return the N most recent runs ordered by `startedAt` DESC, filtered by project.
+   *
+   * @throws `DOMException` with `name === 'AbortError'` when
+   *   `options.signal` aborts — server-side cancel is fired via
+   *   `cancelOnAbort`.
+   * @throws {@link StoreError} when the postgres driver rejects the query.
+   */
   async getRecentRuns(options: GetRecentRunsOptions): Promise<RecentRun[]> {
     options.signal?.throwIfAborted()
     const { limit, project = null, signal } = options
@@ -421,13 +469,23 @@ export class PostgresStore implements IStore {
     }))
   }
 
-  /** Gracefully close the underlying PostgreSQL connection pool. */
+  /**
+   * Gracefully close the underlying PostgreSQL connection pool.
+   *
+   * @throws {@link StoreError} when `sql.end()` errors draining pending
+   *   queries or releasing the connection.
+   */
   async close(): Promise<void> {
     await this.wrap('close', () => this.sql.end())
   }
 }
 
-/** Lazy plugin descriptor — `create(config)` builds a PostgresStore from the resolved config. */
+/**
+ * Lazy plugin descriptor — `create(config)` builds a PostgresStore from the
+ * resolved config.
+ *
+ * @throws `Error` from `create()` when `config.store.type !== 'postgres'`.
+ */
 export const postgresStorePlugin = definePlugin({
   name: 'store-postgres',
   configSchema: postgresStoreOptionsSchema,

--- a/packages/store-sqlite/src/index.ts
+++ b/packages/store-sqlite/src/index.ts
@@ -109,6 +109,7 @@ export class SqliteStore implements IStore {
   /**
    * Open (or create) a SQLite store.
    * @param options - Store configuration; uses sensible defaults when omitted.
+   * @throws {@link ValidationError} when `options` fails schema validation.
    */
   constructor(options: SqliteStoreOptions = {}) {
     const validated = parse(sqliteStoreOptionsSchema, options)
@@ -130,6 +131,10 @@ export class SqliteStore implements IStore {
    * tracks applied versions in the `schema_version` table, and for databases
    * created before versioning existed, seeds a baseline by probing which
    * columns already exist — so we never re-run DDL that would fail.
+   *
+   * @throws {@link SQLiteError} (from `bun:sqlite`) when a migration DDL
+   *   statement fails — e.g. corrupt DB file, insufficient filesystem
+   *   permissions.
    */
   async migrate(): Promise<void> {
     this.db.exec(CREATE_SCHEMA_VERSION_TABLE)
@@ -194,6 +199,9 @@ export class SqliteStore implements IStore {
   /**
    * Record a new test run. Called at the start of a test session.
    * @param input - Run metadata including ID, timestamp, and optional git info.
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link SQLiteError} (from `bun:sqlite`) when the insert is
+   *   rejected — most commonly a duplicate `run_id`.
    */
   async insertRun(input: InsertRunInput): Promise<void> {
     parse(insertRunInputSchema, input)
@@ -216,6 +224,8 @@ export class SqliteStore implements IStore {
    * Finalize a run with end-of-session stats (duration, pass/fail counts, status).
    * @param runId - The run to update.
    * @param input - Completion data for the run.
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link SQLiteError} (from `bun:sqlite`) when the update fails.
    */
   async updateRun(runId: string, input: UpdateRunInput): Promise<void> {
     parse(updateRunInputSchema, input)
@@ -245,6 +255,10 @@ export class SqliteStore implements IStore {
   /**
    * Record an individual test failure within a run.
    * @param input - Failure details including test identity, error info, and timing.
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link SQLiteError} (from `bun:sqlite`) when the insert fails —
+   *   e.g. foreign-key violation when `input.runId` has no matching row in
+   *   `runs`.
    */
   async insertFailure(input: InsertFailureInput): Promise<void> {
     parse(insertFailureInputSchema, input)
@@ -265,7 +279,14 @@ export class SqliteStore implements IStore {
     )
   }
 
-  /** Insert multiple failures in a single SQLite transaction. */
+  /**
+   * Insert multiple failures in a single SQLite transaction.
+   *
+   * @throws {@link ValidationError} when any entry in `inputs` fails schema
+   *   validation — the transaction rolls back and nothing is written.
+   * @throws {@link SQLiteError} (from `bun:sqlite`) when the transaction
+   *   fails at the driver level.
+   */
   async insertFailures(inputs: readonly InsertFailureInput[]): Promise<void> {
     if (inputs.length === 0) return
     this.db.transaction(() => {
@@ -323,6 +344,11 @@ export class SqliteStore implements IStore {
    *
    * @param options - Window size and threshold overrides.
    * @returns Flaky patterns sorted by recent failure count descending.
+   * @throws {@link ValidationError} when `options` fails schema validation.
+   * @throws `DOMException` with `name === 'AbortError'` when
+   *   `options.signal` aborts before the query starts — `bun:sqlite` is
+   *   synchronous so mid-query cancellation is not supported.
+   * @throws {@link SQLiteError} (from `bun:sqlite`) when the query fails.
    */
   async getNewPatterns(
     options: GetNewPatternsOptions = {},
@@ -398,7 +424,13 @@ export class SqliteStore implements IStore {
     return patterns
   }
 
-  /** Return the N most recent runs ordered by `startedAt` DESC, filtered by project. */
+  /**
+   * Return the N most recent runs ordered by `startedAt` DESC, filtered by project.
+   *
+   * @throws `DOMException` with `name === 'AbortError'` when
+   *   `options.signal` aborts before the query starts.
+   * @throws {@link SQLiteError} (from `bun:sqlite`) when the query fails.
+   */
   async getRecentRuns(options: GetRecentRunsOptions): Promise<RecentRun[]> {
     options.signal?.throwIfAborted()
     const { limit, project = null } = options
@@ -457,7 +489,12 @@ export class SqliteStore implements IStore {
   }
 }
 
-/** Lazy plugin descriptor — `create(config)` builds a SqliteStore from the resolved config. */
+/**
+ * Lazy plugin descriptor — `create(config)` builds a SqliteStore from the
+ * resolved config.
+ *
+ * @throws `Error` from `create()` when `config.store.type !== 'sqlite'`.
+ */
 export const sqliteStorePlugin = definePlugin({
   name: 'store-sqlite',
   configSchema: sqliteStoreOptionsSchema,

--- a/packages/store-supabase/src/index.ts
+++ b/packages/store-supabase/src/index.ts
@@ -68,7 +68,14 @@ export class SupabaseStore implements IStore {
   private failuresTable: string
   private retryOptions: RetryOptions
 
-  /** Validate options, construct a supabase-js client, and resolve the runs/failures table names from `tablePrefix` (default `flaky_test`). */
+  /**
+   * Validate options, construct a supabase-js client, and resolve the
+   * runs/failures table names from `tablePrefix` (default `flaky_test`).
+   *
+   * @throws {@link ValidationError} when `options` fails schema validation.
+   * @throws `Error` when `tablePrefix` contains characters outside
+   *   `[a-z0-9_]` (via `validateTablePrefix`).
+   */
   constructor(options: SupabaseStoreOptions) {
     const validated = parse(supabaseStoreOptionsSchema, options)
     // Validate the prefix before creating any client — a malicious prefix
@@ -85,6 +92,10 @@ export class SupabaseStore implements IStore {
    * Supabase does not support DDL through the JS client.
    * Tables must be created via the Supabase Dashboard SQL editor or migrations.
    * See the docs for the required schema: https://brewpirate.github.io/flaky-tests/stores/supabase/
+   *
+   * @throws {@link StoreError} when the runs table isn't reachable — the
+   *   error message points at the docs, and `.cause` is the underlying
+   *   supabase-js error (auth, network, or missing table).
    */
   async migrate(): Promise<void> {
     // Verify tables exist by attempting a lightweight query
@@ -102,7 +113,14 @@ export class SupabaseStore implements IStore {
     }
   }
 
-  /** Insert a new run row at the start of a test session so failures can reference it via `run_id`. */
+  /**
+   * Insert a new run row at the start of a test session so failures can
+   * reference it via `run_id`.
+   *
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link StoreError} when supabase-js returns a non-null `error`
+   *   (auth, RLS policy rejection, duplicate key, network).
+   */
   async insertRun(input: InsertRunInput): Promise<void> {
     parse(insertRunInputSchema, input)
     const { error } = await this.client.from(this.runsTable).insert({
@@ -127,6 +145,8 @@ export class SupabaseStore implements IStore {
    * Update an existing test run with final results.
    * @param runId - The run to update (matched via `run_id` column).
    * @param input - Fields to set (nulls are written explicitly).
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link StoreError} when supabase-js returns a non-null `error`.
    */
   async updateRun(runId: string, input: UpdateRunInput): Promise<void> {
     parse(updateRunInputSchema, input)
@@ -151,7 +171,12 @@ export class SupabaseStore implements IStore {
       })
   }
 
-  /** Record a single test failure. `durationMs` is rounded to the nearest integer. */
+  /**
+   * Record a single test failure. `durationMs` is rounded to the nearest integer.
+   *
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link StoreError} when supabase-js returns a non-null `error`.
+   */
   async insertFailure(input: InsertFailureInput): Promise<void> {
     parse(insertFailureInputSchema, input)
     const { error } = await this.client.from(this.failuresTable).insert({
@@ -177,6 +202,11 @@ export class SupabaseStore implements IStore {
   /**
    * Insert multiple failures. Supabase does not support transactions through the
    * JS client, so this uses a single bulk insert call for atomicity at the REST level.
+   *
+   * @throws {@link ValidationError} when any entry in `inputs` fails schema
+   *   validation — nothing is sent.
+   * @throws {@link StoreError} when supabase-js returns a non-null `error`
+   *   on the bulk insert.
    */
   async insertFailures(inputs: readonly InsertFailureInput[]): Promise<void> {
     if (inputs.length === 0) return
@@ -209,6 +239,13 @@ export class SupabaseStore implements IStore {
    * Returns tests that failed >= `threshold` times recently but zero times in the
    * prior window, sorted by failure count descending. Only considers runs with
    * fewer than 10 total failures and a non-null `ended_at`.
+   *
+   * @throws {@link ValidationError} when `options` fails schema validation.
+   * @throws `DOMException` with `name === 'AbortError'` when
+   *   `options.signal` aborts — forwarded to supabase-js via
+   *   `.abortSignal()`, then re-asserted via `throwIfAborted()` after the
+   *   await to normalize the shape.
+   * @throws {@link StoreError} when supabase-js returns a non-null `error`.
    */
   async getNewPatterns(
     options: GetNewPatternsOptions = {},
@@ -342,7 +379,15 @@ export class SupabaseStore implements IStore {
     return patterns
   }
 
-  /** Return the N most recent runs ordered by `startedAt` DESC, filtered by project. */
+  /**
+   * Return the N most recent runs ordered by `startedAt` DESC, filtered by project.
+   *
+   * @throws `DOMException` with `name === 'AbortError'` when
+   *   `options.signal` aborts — forwarded to supabase-js via
+   *   `.abortSignal()`, then re-asserted via `throwIfAborted()` after the
+   *   await to normalize the shape.
+   * @throws {@link StoreError} when supabase-js returns a non-null `error`.
+   */
   async getRecentRuns(options: GetRecentRunsOptions): Promise<RecentRun[]> {
     options.signal?.throwIfAborted()
     const { limit, project = null, signal } = options
@@ -412,7 +457,12 @@ export class SupabaseStore implements IStore {
   }
 }
 
-/** Lazy plugin descriptor — `create(config)` builds a SupabaseStore from the resolved config. */
+/**
+ * Lazy plugin descriptor — `create(config)` builds a SupabaseStore from the
+ * resolved config.
+ *
+ * @throws `Error` from `create()` when `config.store.type !== 'supabase'`.
+ */
 export const supabaseStorePlugin = definePlugin({
   name: 'store-supabase',
   configSchema: supabaseStoreOptionsSchema,

--- a/packages/store-turso/src/index.ts
+++ b/packages/store-turso/src/index.ts
@@ -80,7 +80,11 @@ export class TursoStore implements IStore {
   private client: Client
   private retryOptions: RetryOptions
 
-  /** Builds the libSQL client from a validated URL and optional auth token. */
+  /**
+   * Builds the libSQL client from a validated URL and optional auth token.
+   *
+   * @throws {@link ValidationError} when `options` fails schema validation.
+   */
   constructor(options: TursoStoreOptions) {
     const validated = parse(tursoStoreOptionsSchema, options)
     this.client = createClient({
@@ -111,6 +115,9 @@ export class TursoStore implements IStore {
    * applying pending migrations from {@link SQLITE_MIGRATIONS}. Tracks
    * applied versions in a `schema_version` table and seeds a baseline for
    * databases created before versioning landed by probing the live schema.
+   *
+   * @throws {@link StoreError} when a migration statement fails at the
+   *   libSQL driver level (network, credentials, incompatible server).
    */
   async migrate(): Promise<void> {
     await this.wrap('migrate', async () => {
@@ -217,7 +224,13 @@ export class TursoStore implements IStore {
     })
   }
 
-  /** Persist a new test-run row. Call before any failures are recorded. */
+  /**
+   * Persist a new test-run row. Call before any failures are recorded.
+   *
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link StoreError} when the libSQL driver rejects the insert
+   *   (network, auth, duplicate `run_id`, etc.).
+   */
   async insertRun(input: InsertRunInput): Promise<void> {
     parse(insertRunInputSchema, input)
     await this.wrap('insertRun', () =>
@@ -237,7 +250,12 @@ export class TursoStore implements IStore {
     )
   }
 
-  /** Update a run with its final summary (status, counts, duration). */
+  /**
+   * Update a run with its final summary (status, counts, duration).
+   *
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link StoreError} when the libSQL driver rejects the update.
+   */
   async updateRun(runId: string, input: UpdateRunInput): Promise<void> {
     parse(updateRunInputSchema, input)
     await this.wrap('updateRun', () =>
@@ -265,7 +283,12 @@ export class TursoStore implements IStore {
     )
   }
 
-  /** Record a single test failure linked to an existing run. */
+  /**
+   * Record a single test failure linked to an existing run.
+   *
+   * @throws {@link ValidationError} when `input` fails schema validation.
+   * @throws {@link StoreError} when the libSQL driver rejects the insert.
+   */
   async insertFailure(input: InsertFailureInput): Promise<void> {
     parse(insertFailureInputSchema, input)
     await this.wrap('insertFailure', () =>
@@ -288,7 +311,13 @@ export class TursoStore implements IStore {
     )
   }
 
-  /** Insert multiple failures in a single batch transaction. */
+  /**
+   * Insert multiple failures in a single batch transaction.
+   *
+   * @throws {@link ValidationError} when any entry in `inputs` fails schema
+   *   validation — the batch is not sent.
+   * @throws {@link StoreError} when the libSQL driver rejects the batch.
+   */
   async insertFailures(inputs: readonly InsertFailureInput[]): Promise<void> {
     if (inputs.length === 0) return
     await this.wrap('insertFailures', () =>
@@ -325,6 +354,12 @@ export class TursoStore implements IStore {
    * @param options.windowDays - Length of the recent window (default 7).
    * @param options.threshold  - Minimum recent failures to qualify (default 2).
    * @returns Patterns sorted by recent failure count descending.
+   * @throws {@link ValidationError} when `options` fails schema validation.
+   * @throws `DOMException` with `name === 'AbortError'` when
+   *   `options.signal` aborts — via `throwIfAborted()` at entry or the
+   *   `raceAbort` wrapper that rejects the caller while the underlying
+   *   libSQL request continues in the background.
+   * @throws {@link StoreError} when the libSQL driver rejects the query.
    */
   async getNewPatterns(
     options: GetNewPatternsOptions = {},
@@ -400,7 +435,13 @@ export class TursoStore implements IStore {
     return patterns
   }
 
-  /** Return the N most recent runs ordered by `startedAt` DESC, filtered by project. */
+  /**
+   * Return the N most recent runs ordered by `startedAt` DESC, filtered by project.
+   *
+   * @throws `DOMException` with `name === 'AbortError'` when
+   *   `options.signal` aborts.
+   * @throws {@link StoreError} when the libSQL driver rejects the query.
+   */
   async getRecentRuns(options: GetRecentRunsOptions): Promise<RecentRun[]> {
     options.signal?.throwIfAborted()
     const { limit, project = null, signal } = options
@@ -447,7 +488,12 @@ export class TursoStore implements IStore {
     })
   }
 
-  /** Close the underlying libSQL connection. */
+  /**
+   * Close the underlying libSQL connection.
+   *
+   * @throws {@link StoreError} when the driver's `close()` throws — rare
+   *   in practice, but wrapped for a uniform error surface.
+   */
   async close(): Promise<void> {
     await this.wrap('close', async () => {
       this.client.close()
@@ -455,7 +501,12 @@ export class TursoStore implements IStore {
   }
 }
 
-/** Lazy plugin descriptor — `create(config)` builds a TursoStore from the resolved config. */
+/**
+ * Lazy plugin descriptor — `create(config)` builds a TursoStore from the
+ * resolved config.
+ *
+ * @throws `Error` from `create()` when `config.store.type !== 'turso'`.
+ */
 export const tursoStorePlugin = definePlugin({
   name: 'store-turso',
   configSchema: tursoStoreOptionsSchema,


### PR DESCRIPTION
Closes #58.

## Summary
Pure-documentation sweep — no behavior or signature changes. Every public method on \`SqliteStore\`, \`TursoStore\`, \`PostgresStore\`, \`SupabaseStore\`, plus each \`*StorePlugin.create\`, now has \`@throws\` tags naming the error types it can produce and the condition that fires them.

## Coverage matrix

| Method | Errors documented |
|---|---|
| \`constructor\` | \`ValidationError\` + \`Error\` (invalid tablePrefix on pg/supabase) |
| \`migrate\` | \`StoreError\` (turso/pg/supabase) / \`SQLiteError\` (sqlite) |
| \`insertRun\` \`updateRun\` \`insertFailure\` \`insertFailures\` | \`ValidationError\` + \`StoreError\` / \`SQLiteError\` |
| \`getNewPatterns\` | \`ValidationError\` + \`AbortError\` + \`StoreError\` / \`SQLiteError\` |
| \`getRecentRuns\` | \`AbortError\` + \`StoreError\` / \`SQLiteError\` |
| \`close\` | \`StoreError\` (turso/pg) — no-op / no-throw on sqlite + supabase |
| \`*StorePlugin.create\` | \`Error\` on \`config.store.type\` mismatch |

\`AbortError\` is only documented where \`options.signal\` is accepted. Wording per adapter distinguishes the cancellation path (\`throwIfAborted\` entry check, libsql \`raceAbort\`, postgres server-side \`query.cancel()\`, supabase native \`.abortSignal()\`).

## Honest-docs note
SQLite's \`@throws\` names \`SQLiteError\` (bun:sqlite's native class) rather than \`StoreError\`. SQLite is the one adapter that does **not** use a \`wrap()\` helper, so errors escape unwrapped — documenting \`StoreError\` there would be inaccurate. Adding \`wrap()\` for parity would be a behavior change and is out of scope for this pure-TSDoc issue; worth a follow-up.

## Verification
- [x] \`bun run typecheck\` clean across 8 packages
- [x] \`bun run check\` (biome) clean — 130 files
- [x] \`bun test\` — 345 pass / 0 fail (unchanged from main)
- [x] \`bun run build:types\` clean — declaration output includes the new tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)