### PR TITLE
docs(core): add @throws tags to validation + plugin + retry helpers (closes #59)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -274,6 +274,14 @@ function isConfigObject(value: unknown): value is Config {
  *   - no args → read `process.env` (memoized; repeated calls are free)
  *   - a `NodeJS.ProcessEnv` record → parse that instead (fresh each call)
  *   - a pre-built `Config` → install it as the cached resolution (useful in tests)
+ *
+ * @throws {@link ConfigError} when a required env var is missing for the
+ *   selected store (`FLAKY_TESTS_CONNECTION_STRING` for turso/supabase,
+ *   `FLAKY_TESTS_AUTH_TOKEN` for supabase), when a numeric env var is not
+ *   a positive number (`FLAKY_TESTS_WINDOW`, `FLAKY_TESTS_THRESHOLD`),
+ *   when `FLAKY_TESTS_STORE` names an unknown type, or when the final
+ *   object fails the arktype config schema. The original cause is
+ *   preserved on `error.cause`.
  */
 export function resolveConfig(source?: NodeJS.ProcessEnv | Config): Config {
   if (isConfigObject(source)) {

--- a/packages/core/src/create-store.ts
+++ b/packages/core/src/create-store.ts
@@ -65,6 +65,25 @@ function findDescriptor(storeType: string) {
 
 const defaultImporter: StoreModuleImporter = (spec) => import(spec)
 
+/**
+ * Resolve a store instance from the unified config. Looks up a
+ * registered plugin descriptor by store type; if none is found, tries
+ * to dynamic-import `config.store.module` and then the convention
+ * `@flaky-tests/store-<type>` so each adapter self-registers via its
+ * own `definePlugin` call.
+ *
+ * @throws {@link MissingStorePackageError} when no matching plugin
+ *   descriptor is registered and none of the candidate module specifiers
+ *   can be imported. The error names both the store type and the exact
+ *   install command.
+ * @throws re-throws any non-"module-not-found" error from `importer()`
+ *   unchanged so real import failures (syntax errors, runtime throws in
+ *   the adapter's top-level code) surface with their original stacks.
+ * @throws re-throws any error from the adapter's `create(config)` —
+ *   this function does **not** wrap constructor failures. A store that
+ *   throws `ValidationError` or `Error` from its constructor will
+ *   propagate that error as-is.
+ */
 export async function createStoreFromConfig(
   config: Config,
   importer: StoreModuleImporter = defaultImporter,

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -40,9 +40,14 @@ function getRegistry(): Registry {
 }
 
 /**
- * Register a plugin descriptor. Throws if a plugin with the same name is
- * already registered — silent overwrites would make the registry a
- * last-import-wins lottery.
+ * Register a plugin descriptor.
+ *
+ * Silent overwrites would make the registry a last-import-wins lottery,
+ * so duplicate names are rejected. Re-calling `definePlugin` with the
+ * same descriptor instance (module-init idempotence) is allowed.
+ *
+ * @throws `Error` when another descriptor with `descriptor.name` is
+ *   already registered and it isn't the same object reference.
  */
 export function definePlugin<Instance>(
   descriptor: FlakyPluginDescriptor<Instance>,

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -125,9 +125,18 @@ export function isRetryableError(error: unknown): boolean {
  * that delay. An `AbortSignal` cancels any pending sleep and rejects with
  * the signal's reason.
  *
- * On exhaustion, re-throws the last caught error so callers see the real
- * driver exception (wrapped in `StoreError` by the store adapter's own
- * `wrap` helper).
+ * **Re-throw contract:** on exhaustion the last caught error is re-thrown
+ * unchanged. Non-retryable errors are also re-thrown as-is on the first
+ * attempt. Callers see the real driver exception (which store adapters
+ * wrap in `StoreError` via their own `wrap` helper further up the stack).
+ *
+ * @throws `TypeError` when `opts.attempts` is not a positive integer — a
+ *   configuration bug, thrown before `op` runs so the failure is loud.
+ * @throws `DOMException` with `name === 'AbortError'` when `opts.signal`
+ *   is already aborted at entry, or aborts during a pending sleep.
+ * @throws re-throws the caller's own error — whatever `op` surfaces — when
+ *   it is classified non-retryable (first occurrence) or when retry
+ *   attempts are exhausted (last occurrence).
  */
 export async function withRetry<T>(
   op: () => Promise<T>,

--- a/packages/core/src/validate-schemas.ts
+++ b/packages/core/src/validate-schemas.ts
@@ -8,7 +8,12 @@ export class ValidationError extends Error {
   }
 }
 
-/** Parse data against a schema — returns the validated value or throws ValidationError. */
+/**
+ * Parse data against a schema — returns the validated value.
+ *
+ * @throws {@link ValidationError} when `data` fails ArkType validation; the
+ *   thrown error's `summary` field contains ArkType's issue summary.
+ */
 export function parse<T>(schema: Type<T>, data: unknown): T {
   const result = schema(data)
   if (result instanceof type.errors) {
@@ -18,7 +23,13 @@ export function parse<T>(schema: Type<T>, data: unknown): T {
   return result as T
 }
 
-/** Parse an array of items against a schema. Used for getNewPatterns output. */
+/**
+ * Parse an array of items against a schema. Used for `getNewPatterns` output.
+ *
+ * @throws {@link ValidationError} on the first item that fails validation.
+ *   The summary is prefixed with the failing index (`[3]: ...`) so callers
+ *   can locate it.
+ */
 export function parseArray<T>(schema: Type<T>, data: unknown[]): T[] {
   return data.map((item, index) => {
     const result = schema(item)

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -3,12 +3,14 @@ import { ValidationError } from './validate-schemas'
 const TABLE_PREFIX_PATTERN = /^[a-z_][a-z0-9_]*$/
 
 /**
- * Validates a SQL table name prefix. Throws {@link ValidationError} if the
- * prefix contains characters outside the safe identifier set `[a-z0-9_]`.
+ * Validates a SQL table name prefix.
  *
  * Interpolating a user-supplied string into a SQL identifier position
  * (e.g. `${prefix}_runs`) is a path to identifier injection — this guard
  * is the first line of defense; adapters should still quote identifiers.
+ *
+ * @throws {@link ValidationError} when `prefix` contains characters outside
+ *   the safe identifier set `^[a-z_][a-z0-9_]*$`.
  */
 export function validateTablePrefix(prefix: string): void {
   if (!TABLE_PREFIX_PATTERN.test(prefix)) {


### PR DESCRIPTION
Closes #59.

## Summary
Pure-documentation companion to #58 (stores sweep). Six core helper exports now advertise the error types they can produce.

| File | Symbol | Errors documented |
|---|---|---|
| \`validate-schemas.ts\` | \`parse\` | \`ValidationError\` |
| \`validate-schemas.ts\` | \`parseArray\` | \`ValidationError\` (with index prefix) |
| \`validate.ts\` | \`validateTablePrefix\` | \`ValidationError\` |
| \`config.ts\` | \`resolveConfig\` | \`ConfigError\` — five listed trigger conditions |
| \`create-store.ts\` | \`createStoreFromConfig\` | \`MissingStorePackageError\` + re-throw contract for imports and adapter constructors |
| \`plugin.ts\` | \`definePlugin\` | \`Error\` on duplicate-name re-registration |
| \`retry.ts\` | \`withRetry\` | \`TypeError\`, \`AbortError\`, re-throw contract for non-retryable-first-fail and exhaustion |

## Notes
- \`createStoreFromConfig\` now explicitly documents that it does **not** wrap constructor errors from the underlying adapter — they propagate unchanged. That matches current behavior; this PR only writes it down.
- \`withRetry\`'s @throws captures the full contract in one place: the config-validation \`TypeError\` (thrown before \`op\` runs), the \`AbortError\` from pre/mid-sleep aborts, and the re-throw semantics on exhaustion so callers see the real driver exception.

## Verification
- [x] \`bun run typecheck\` — clean across 8 packages
- [x] \`bun run check\` (biome) — 130 files clean
- [x] \`bun test\` — 345 pass / 0 fail (unchanged from main)
- [x] \`bun run build:types\` — declarations include the new tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)