### PR TITLE
refactor(core): PR 2 — shared StoreError wrapper (part of #68)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,7 @@ export {
   detectBaselineVersion,
   type FlakyPluginDescriptor,
   listRegisteredPlugins,
+  makeStoreWrapper,
   mapRowToPattern,
   type PatternRow,
   pendingMigrations,
@@ -71,6 +72,7 @@ export {
   type SchemaInspector,
   SQLITE_MIGRATIONS,
   type SqliteMigration,
+  type StoreCallWrapper,
   type StoreModuleImporter,
   stripTimestampPrefix,
 } from './store'

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -18,4 +18,8 @@ export {
   listRegisteredPlugins,
   resetPluginRegistryForTesting,
 } from './plugin'
-export { stripTimestampPrefix } from './store-utils'
+export {
+  makeStoreWrapper,
+  type StoreCallWrapper,
+  stripTimestampPrefix,
+} from './store-utils'

--- a/packages/core/src/store/store-utils.ts
+++ b/packages/core/src/store/store-utils.ts
@@ -1,8 +1,65 @@
+import { StoreError } from '#core/errors/errors'
+import { extractMessage } from '#core/observe/categorize'
+
 /**
  * Separator used in the timestamp-prefix trick for MAX() aggregation.
  * CHAR(1) / chr(1) is a control character that won't appear in error messages.
  */
 const TIMESTAMP_SEPARATOR = '\x01'
+
+/** A bound wrapper returned by {@link makeStoreWrapper}. */
+export type StoreCallWrapper = <T>(
+  method: string,
+  fn: () => Promise<T>,
+) => Promise<T>
+
+/**
+ * Build an adapter-scoped wrapper that turns any thrown driver error into a
+ * {@link StoreError} with `package`, `method`, `message`, and `cause` set.
+ *
+ * Each store adapter creates one instance in its constructor
+ * (`this.wrap = makeStoreWrapper('@flaky-tests/store-xxx')`) and calls
+ * `this.wrap('methodName', () => driverCall())` at every public entry
+ * point. Centralising the try/catch here lets the IStore contract's
+ * "implementations MUST wrap driver errors in StoreError" clause be
+ * satisfied identically by every backend instead of re-declared per file.
+ *
+ * @example
+ * ```ts
+ * class MyStore implements IStore {
+ *   private wrap = makeStoreWrapper('@flaky-tests/store-mything')
+ *   async getNewPatterns() {
+ *     return this.wrap('getNewPatterns', () => this.client.query(...))
+ *   }
+ * }
+ * ```
+ */
+/**
+ * Re-throw unchanged when an aborted signal surfaces: the IStore contract
+ * documents `AbortError` as the abort shape across every adapter, so the
+ * wrapper must not hide it behind a StoreError wrapper.
+ */
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
+export function makeStoreWrapper(packageName: string): StoreCallWrapper {
+  return async <T>(method: string, fn: () => Promise<T>): Promise<T> => {
+    try {
+      return await fn()
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw error
+      }
+      throw new StoreError({
+        package: packageName,
+        method,
+        message: extractMessage(error),
+        cause: error,
+      })
+    }
+  }
+}
 
 /**
  * Strips the `timestamp + CHAR(1)` prefix that the MAX()-based

--- a/packages/store-postgres/src/index.ts
+++ b/packages/store-postgres/src/index.ts
@@ -4,7 +4,6 @@ import {
   DEFAULT_THRESHOLD,
   DEFAULT_WINDOW_DAYS,
   definePlugin,
-  extractMessage,
   type FailureRow,
   type FlakyPattern,
   flakyPatternSchema,
@@ -19,6 +18,7 @@ import {
   type ListFailuresOptions,
   MAX_FAILED_TESTS_PER_RUN,
   MS_PER_DAY,
+  makeStoreWrapper,
   mapRowToPattern,
   parse,
   parseArray,
@@ -26,7 +26,6 @@ import {
   type RetryOptions,
   type RunStatus,
   retryOptionsSchema,
-  StoreError,
   type UpdateRunInput,
   updateRunInputSchema,
   validateTablePrefix,
@@ -100,6 +99,8 @@ export class PostgresStore implements IStore {
   private runsTable: string
   private failuresTable: string
   private retryOptions: RetryOptions
+  /** Wraps driver calls in {@link StoreError}; see {@link makeStoreWrapper}. */
+  private wrap = makeStoreWrapper(PACKAGE)
 
   /**
    * Accepts either a full `connectionString` or individual host/port/credentials fields.
@@ -132,20 +133,6 @@ export class PostgresStore implements IStore {
           password: validated.password,
         }),
         ...(validated.ssl !== undefined && { ssl: validated.ssl }),
-      })
-    }
-  }
-
-  /** Wraps a driver call so any thrown postgres.js error becomes a {@link StoreError} with `cause` preserved for stack inspection. */
-  private async wrap<T>(method: string, fn: () => Promise<T>): Promise<T> {
-    try {
-      return await fn()
-    } catch (error) {
-      throw new StoreError({
-        package: PACKAGE,
-        method,
-        message: extractMessage(error),
-        cause: error,
       })
     }
   }

--- a/packages/store-supabase/src/index.ts
+++ b/packages/store-supabase/src/index.ts
@@ -18,6 +18,7 @@ import {
   type ListFailuresOptions,
   MAX_FAILED_TESTS_PER_RUN,
   MS_PER_DAY,
+  makeStoreWrapper,
   parse,
   parseArray,
   type RecentRun,
@@ -59,6 +60,8 @@ export class SupabaseStore implements IStore {
   private runsTable: string
   private failuresTable: string
   private retryOptions: RetryOptions
+  /** Wraps driver calls in {@link StoreError}; see {@link makeStoreWrapper}. */
+  private wrap = makeStoreWrapper(PACKAGE)
 
   /**
    * Validate options, construct a supabase-js client, and resolve the
@@ -284,21 +287,9 @@ export class SupabaseStore implements IStore {
       }
       return (data ?? []) as unknown[]
     }
-    let data: unknown[]
-    try {
-      data = await withRetry(runQuery, {
-        ...this.retryOptions,
-        signal: options.signal,
-      })
-    } catch (error) {
-      options.signal?.throwIfAborted()
-      throw new StoreError({
-        package: PACKAGE,
-        method: 'getNewPatterns',
-        message: error instanceof Error ? error.message : String(error),
-        cause: error,
-      })
-    }
+    const data = await this.wrap('getNewPatterns', () =>
+      withRetry(runQuery, { ...this.retryOptions, signal: options.signal }),
+    )
 
     type Row = {
       test_file: string
@@ -411,18 +402,9 @@ export class SupabaseStore implements IStore {
       }
       return (data ?? []) as unknown[]
     }
-    let data: unknown[]
-    try {
-      data = await withRetry(runQuery, { ...this.retryOptions, signal })
-    } catch (error) {
-      signal?.throwIfAborted()
-      throw new StoreError({
-        package: PACKAGE,
-        method: 'getRecentRuns',
-        message: error instanceof Error ? error.message : String(error),
-        cause: error,
-      })
-    }
+    const data = await this.wrap('getRecentRuns', () =>
+      withRetry(runQuery, { ...this.retryOptions, signal }),
+    )
     type Row = {
       run_id: string
       project: string | null
@@ -523,18 +505,9 @@ export class SupabaseStore implements IStore {
       return (data ?? []) as unknown as Row[]
     }
 
-    let rows: Row[]
-    try {
-      rows = await withRetry(runQuery, { ...this.retryOptions, signal })
-    } catch (error) {
-      signal?.throwIfAborted()
-      throw new StoreError({
-        package: PACKAGE,
-        method: 'listFailures',
-        message: error instanceof Error ? error.message : String(error),
-        cause: error,
-      })
-    }
+    const rows = await this.wrap('listFailures', () =>
+      withRetry(runQuery, { ...this.retryOptions, signal }),
+    )
 
     return rows.map((row) => ({
       runId: row.run_id,

--- a/packages/store-turso/src/index.ts
+++ b/packages/store-turso/src/index.ts
@@ -6,7 +6,6 @@ import {
   DEFAULT_WINDOW_DAYS,
   definePlugin,
   detectBaselineVersion,
-  extractMessage,
   type FailureRow,
   type FlakyPattern,
   flakyPatternSchema,
@@ -21,6 +20,7 @@ import {
   type ListFailuresOptions,
   MAX_FAILED_TESTS_PER_RUN,
   MS_PER_DAY,
+  makeStoreWrapper,
   mapRowToPattern,
   type PatternRow,
   parse,
@@ -35,7 +35,6 @@ import {
   type SchemaInspector,
   SQLITE_MIGRATIONS,
   type SqliteMigration,
-  StoreError,
   type UpdateRunInput,
   updateRunInputSchema,
   withRetry,
@@ -71,6 +70,8 @@ interface SchemaVersionRow {
 export class TursoStore implements IStore {
   private client: Client
   private retryOptions: RetryOptions
+  /** Wraps driver calls in {@link StoreError}; see {@link makeStoreWrapper}. */
+  private wrap = makeStoreWrapper(PACKAGE)
 
   /**
    * Builds the libSQL client from a validated URL and optional auth token.
@@ -86,20 +87,6 @@ export class TursoStore implements IStore {
       }),
     })
     this.retryOptions = validated.retry ?? {}
-  }
-
-  /** Wraps a driver call so any thrown libSQL error becomes a {@link StoreError} with `cause` preserved for stack inspection. */
-  private async wrap<T>(method: string, fn: () => Promise<T>): Promise<T> {
-    try {
-      return await fn()
-    } catch (error) {
-      throw new StoreError({
-        package: PACKAGE,
-        method,
-        message: extractMessage(error),
-        cause: error,
-      })
-    }
   }
 
   /**


### PR DESCRIPTION
PR 2 of the DRY remediation plan from #68. Consolidate driver-error → \`StoreError\` wrapping that turso, postgres, and supabase each hand-rolled.

## Changes

- **Add \`makeStoreWrapper(packageName)\`** in \`core/src/store/store-utils.ts\`. Returns a bound wrap function; adapters create one in the constructor (\`this.wrap = makeStoreWrapper(PACKAGE)\`) and call \`this.wrap('methodName', () => driverCall())\` at every entry point.
- **AbortError passthrough.** The shared helper re-throws \`AbortError\` unchanged so callers see a uniform abort shape across adapters. Previously turso/postgres wrapped it into \`StoreError\`; supabase already passed it through via manual \`throwIfAborted()\`. New behavior matches the IStore contract's documented "callers receive an \`AbortError\`" clause.
- **turso / postgres**: delete their identical private \`wrap()\` methods and drop the \`StoreError\` / \`extractMessage\` imports that went with them.
- **supabase**: fold the three \`try/catch { signal?.throwIfAborted(); throw new StoreError(...) }\` blocks around \`withRetry\` calls into \`this.wrap('name', () => withRetry(...))\`. The manual abort re-throw goes away — the shared wrapper handles it.

## Public surface

Additions: \`makeStoreWrapper\`, \`StoreCallWrapper\`. No removals.

## Scope note

**sqlite is not adopted in this PR.** It currently throws raw \`bun:sqlite\` errors (out of compliance with the IStore contract's "MUST wrap in StoreError" clause). Adopting the wrapper there is a user-facing error-shape change with potential test ripples — kept out of this PR to keep the DRY consolidation clean. Worth tracking as a follow-up on #68.

## Behavior change worth flagging

For **turso and postgres**, aborting via \`AbortSignal\` now surfaces a native \`AbortError\` instead of \`StoreError{cause: AbortError}\`. Matches supabase's existing behavior and the IStore docstring. Downstream callers that matched on \`StoreError\` for abort cases will need to check for \`AbortError\` too — but anyone doing that is already benefiting from a clearer contract.

## Test plan

- [x] \`bun test\` — 345 pass, 0 fail
- [x] \`bun run typecheck\` — clean
- [x] \`.githooks/pre-commit\` — full pipeline green

## Diff

6 files changed, 82 insertions(+), 72 deletions(-). Net negative despite adding a new public helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)