### PR TITLE
refactor: PR 3 — plugin payload helpers (part of #68)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,12 @@ export {
   StoreError,
 } from './errors'
 export {
+  type BuildInsertFailureInputOpts,
+  type BuildInsertRunInputOpts,
+  type BuildUpdateRunInputOpts,
+  buildInsertFailureInput,
+  buildInsertRunInput,
+  buildUpdateRunInput,
   captureGitInfo,
   categorizeError,
   DescribeStack,

--- a/packages/core/src/observe/build-inputs.ts
+++ b/packages/core/src/observe/build-inputs.ts
@@ -1,0 +1,150 @@
+import {
+  insertFailureInputSchema,
+  insertRunInputSchema,
+  updateRunInputSchema,
+} from '#core/schema/schemas'
+import { parse } from '#core/schema/validate-schemas'
+import type {
+  GitInfo,
+  InsertFailureInput,
+  InsertRunInput,
+  UpdateRunInput,
+} from '#core/types'
+import { categorizeError, extractMessage, extractStack } from './categorize'
+
+/** Options for {@link buildInsertRunInput}. */
+export interface BuildInsertRunInputOpts {
+  /** Identifier for the run about to start. */
+  runId: string
+  /** Runtime version string — e.g. `Bun.version`, `process.version`. */
+  runtimeVersion: string
+  /** Git metadata captured at run start (see {@link captureGitInfo}). */
+  git: GitInfo
+  /**
+   * Project label scoping the run. Defaults to `null` so adapters' NULL-
+   * vs-value filter behaves consistently.
+   */
+  project?: string | null
+  /**
+   * Run start timestamp as an ISO string. Defaults to `new Date().toISOString()`;
+   * callers pass an explicit value when they need to tie it to an earlier
+   * `performance.now()` sample.
+   */
+  startedAt?: string
+  /**
+   * Raw CLI args for this test invocation. Defaults to
+   * `process.argv.slice(2).join(' ')` — the same shape both plugins were
+   * reconstructing individually.
+   */
+  testArgs?: string
+}
+
+/**
+ * Build a validated {@link InsertRunInput} for the "test run is starting"
+ * write. Centralises the shape both plugin-bun and plugin-vitest were
+ * hand-rolling, including the `process.argv` reconstruction and the
+ * git-info/project fallbacks.
+ */
+export function buildInsertRunInput(
+  opts: BuildInsertRunInputOpts,
+): InsertRunInput {
+  const {
+    runId,
+    runtimeVersion,
+    git,
+    project = null,
+    startedAt = new Date().toISOString(),
+    testArgs = process.argv.slice(2).join(' '),
+  } = opts
+  return parse(insertRunInputSchema, {
+    runId,
+    project,
+    startedAt,
+    gitSha: git.sha,
+    gitDirty: git.dirty,
+    runtimeVersion,
+    testArgs,
+  })
+}
+
+/** Options for {@link buildInsertFailureInput}. */
+export interface BuildInsertFailureInputOpts {
+  runId: string
+  testFile: string
+  testName: string
+  /** The thrown value — coerced through the core error helpers for kind/message/stack. */
+  error: unknown
+  /** Observed duration for the failing test. `null` when the framework doesn't report one. */
+  durationMs: number | null
+  /** Failure timestamp. Defaults to `new Date().toISOString()`. */
+  failedAt?: string
+}
+
+/**
+ * Build a validated {@link InsertFailureInput} for a single failure event.
+ * Runs the thrown value through {@link categorizeError}, {@link extractMessage},
+ * and {@link extractStack} so both plugins produce the same columns.
+ */
+export function buildInsertFailureInput(
+  opts: BuildInsertFailureInputOpts,
+): InsertFailureInput {
+  const {
+    runId,
+    testFile,
+    testName,
+    error,
+    durationMs,
+    failedAt = new Date().toISOString(),
+  } = opts
+  return parse(insertFailureInputSchema, {
+    runId,
+    testFile,
+    testName,
+    failureKind: categorizeError(error),
+    errorMessage: error == null ? null : extractMessage(error),
+    errorStack: error == null ? null : extractStack(error),
+    durationMs: durationMs == null ? null : Math.round(durationMs),
+    failedAt,
+  })
+}
+
+/** Options for {@link buildUpdateRunInput}. */
+export interface BuildUpdateRunInputOpts {
+  totalTests: number
+  passedTests: number
+  failedTests: number
+  errorsBetweenTests: number
+  durationMs: number
+  /** Run end timestamp. Defaults to `new Date().toISOString()`. */
+  endedAt?: string
+}
+
+/**
+ * Build a validated {@link UpdateRunInput} for the "test run finished"
+ * write. Derives `status` — `fail` when any test failed or any
+ * between-tests error fired, `pass` otherwise — so both plugins arrive at
+ * the same rule.
+ */
+export function buildUpdateRunInput(
+  opts: BuildUpdateRunInputOpts,
+): UpdateRunInput {
+  const {
+    totalTests,
+    passedTests,
+    failedTests,
+    errorsBetweenTests,
+    durationMs,
+    endedAt = new Date().toISOString(),
+  } = opts
+  const status: 'pass' | 'fail' =
+    failedTests > 0 || errorsBetweenTests > 0 ? 'fail' : 'pass'
+  return parse(updateRunInputSchema, {
+    endedAt,
+    durationMs,
+    status,
+    totalTests,
+    passedTests,
+    failedTests,
+    errorsBetweenTests,
+  })
+}

--- a/packages/core/src/observe/index.ts
+++ b/packages/core/src/observe/index.ts
@@ -1,3 +1,11 @@
+export {
+  type BuildInsertFailureInputOpts,
+  type BuildInsertRunInputOpts,
+  type BuildUpdateRunInputOpts,
+  buildInsertFailureInput,
+  buildInsertRunInput,
+  buildUpdateRunInput,
+} from './build-inputs'
 export { categorizeError, extractMessage, extractStack } from './categorize'
 export { DescribeStack } from './describe-stack'
 export { captureGitInfo, type RunCommand } from './git'

--- a/packages/plugin-bun/src/preload.ts
+++ b/packages/plugin-bun/src/preload.ts
@@ -23,16 +23,12 @@ import * as bunTest from 'bun:test'
 import { afterAll, mock } from 'bun:test'
 import type { IStore } from '@flaky-tests/core'
 import {
-  categorizeError,
+  buildInsertFailureInput,
+  buildInsertRunInput,
+  buildUpdateRunInput,
   createLogger,
   DescribeStack,
-  extractMessage,
-  extractStack,
-  insertFailureInputSchema,
-  insertRunInputSchema,
-  parse,
   resolveConfig,
-  updateRunInputSchema,
 } from '@flaky-tests/core'
 import { captureGitInfo } from './git'
 import { createPendingWriteTracker } from './pending-writes'
@@ -138,14 +134,12 @@ export function createPreload(store: IStore): void {
 
   safeVoid('insertRun', () =>
     store.insertRun(
-      parse(insertRunInputSchema, {
+      buildInsertRunInput({
         runId,
         project,
         startedAt,
-        gitSha: git.sha,
-        gitDirty: git.dirty,
+        git,
         runtimeVersion: Bun.version,
-        testArgs: process.argv.slice(2).join(' '),
       }),
     ),
   )
@@ -160,15 +154,12 @@ export function createPreload(store: IStore): void {
     errorsBetweenTests++
     safeVoid('insertFailure (between-tests)', () =>
       store.insertFailure(
-        parse(insertFailureInputSchema, {
+        buildInsertFailureInput({
           runId,
           testFile: resolveTestFile(error),
           testName: '<between tests>',
-          failureKind: categorizeError(error),
-          errorMessage: extractMessage(error),
-          errorStack: extractStack(error),
+          error,
           durationMs: 0,
-          failedAt: new Date().toISOString(),
         }),
       ),
     )
@@ -185,15 +176,12 @@ export function createPreload(store: IStore): void {
   }): void => {
     safeVoid('insertFailure', () =>
       store.insertFailure(
-        parse(insertFailureInputSchema, {
+        buildInsertFailureInput({
           runId,
           testFile: opts.testFile,
           testName: opts.testName,
-          failureKind: categorizeError(opts.error),
-          errorMessage: extractMessage(opts.error),
-          errorStack: extractStack(opts.error),
-          durationMs: Math.round(opts.durationMs),
-          failedAt: new Date().toISOString(),
+          error: opts.error,
+          durationMs: opts.durationMs,
         }),
       ),
     )
@@ -301,10 +289,9 @@ export function createPreload(store: IStore): void {
     await store
       .updateRun(
         runId,
-        parse(updateRunInputSchema, {
+        buildUpdateRunInput({
           endedAt,
           durationMs,
-          status,
           totalTests: testsRun,
           passedTests,
           failedTests: testsFailed,

--- a/packages/plugin-vitest/src/index.ts
+++ b/packages/plugin-vitest/src/index.ts
@@ -26,17 +26,13 @@ import type {
   RunCommand,
 } from '@flaky-tests/core'
 import {
+  buildInsertFailureInput,
+  buildInsertRunInput,
+  buildUpdateRunInput,
   captureGitInfo as captureGitInfoCore,
-  categorizeError,
   createLogger,
   definePlugin,
-  extractMessage,
-  extractStack,
-  insertFailureInputSchema,
-  insertRunInputSchema,
-  parse,
   resolveConfig,
-  updateRunInputSchema,
 } from '@flaky-tests/core'
 
 const log = createLogger('plugin-vitest')
@@ -147,14 +143,11 @@ export class FlakyTestsReporter {
       .catch((e: unknown) => log.warn('migrate failed:', e))
     await this.store
       .insertRun(
-        parse(insertRunInputSchema, {
+        buildInsertRunInput({
           runId: this.runId,
           project: resolveConfig().project ?? null,
-          startedAt: new Date().toISOString(),
-          gitSha: git.sha,
-          gitDirty: git.dirty,
+          git,
           runtimeVersion: process.version,
-          testArgs: process.argv.slice(2).join(' '),
         }),
       )
       .catch((e: unknown) => log.warn('insertRun failed:', e))
@@ -202,17 +195,12 @@ export class FlakyTestsReporter {
           failedTests++
           const firstError = (result.errors ?? [])[0]
           failureInputs.push(
-            parse(insertFailureInputSchema, {
+            buildInsertFailureInput({
               runId: this.runId,
               testFile: task.file?.filepath ?? 'unknown',
               testName: getTestPath(task),
-              failureKind: categorizeError(firstError),
-              errorMessage:
-                firstError != null ? extractMessage(firstError) : null,
-              errorStack: firstError != null ? extractStack(firstError) : null,
-              durationMs:
-                result.duration != null ? Math.round(result.duration) : null,
-              failedAt: new Date().toISOString(),
+              error: firstError ?? null,
+              durationMs: result.duration ?? null,
             }),
           )
         }
@@ -232,10 +220,8 @@ export class FlakyTestsReporter {
     await this.store
       .updateRun(
         this.runId,
-        parse(updateRunInputSchema, {
-          endedAt: new Date().toISOString(),
+        buildUpdateRunInput({
           durationMs,
-          status,
           totalTests,
           passedTests,
           failedTests,


### PR DESCRIPTION
PR 3 of the DRY remediation plan in #68. Collapse identical insertRun / insertFailure / updateRun payload construction across plugin-bun and plugin-vitest into three shared helpers.

## New core/observe helpers

- `buildInsertRunInput({ runId, runtimeVersion, git, project?, startedAt?, testArgs? })` — centralises the `process.argv` reconstruction and git/project fallbacks both plugins duplicated.
- `buildInsertFailureInput({ runId, testFile, testName, error, durationMs, failedAt? })` — runs the thrown value through `categorizeError` / `extractMessage` / `extractStack` once instead of twice.
- `buildUpdateRunInput({ totalTests, passedTests, failedTests, errorsBetweenTests, durationMs, endedAt? })` — derives `status` from the fail-count rule both plugins had identically.

All three run their output through the existing arktype schemas so validation behavior stays unchanged.

## Plugin sites refactored

- **plugin-bun/src/preload.ts** — 3 sites: insertRun at run start, insertFailure in the `uncaughtException` hook, insertFailure in the per-test wrapper; plus updateRun in `afterAll`.
- **plugin-vitest/src/index.ts** — 3 sites: insertRun in `onInit`, insertFailure building in `onFinished`'s walk, updateRun in `onFinished`.

Both plugins drop their direct imports of `categorizeError` / `extractMessage` / `extractStack` / `parse` / the three `*InputSchema`s — the helpers own those boundaries now.

## Public surface

Additions only: `buildInsertFailureInput`, `buildInsertRunInput`, `buildUpdateRunInput` + their `Opts` type exports. No removals.

## Test plan

- [x] `bun run typecheck` — clean across all 7 packages
- [x] `bun test` — 345 pass, 0 fail (unchanged)
- [x] `.githooks/pre-commit` — full pipeline green

## Diff

5 files changed, +184 / -47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)