### PR TITLE
chore(release): split release.yml into build + parallel npm/JSR publi…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,16 +185,16 @@ jobs:
           done
 
       - name: Publish to JSR
-        # `--allow-slow-types` will be removed once the 30 slow-types issues
-        # in @flaky-tests/core are fixed (tracked in .local/plans/raise-jsr-score.md,
-        # Tier 3). Until then, publish with the flag so the score caps at
-        # ~95% but publish itself succeeds.
+        # Slow-types are cleared for @flaky-tests/core (Tier 3 of the
+        # JSR score-raise plan). If a future package adds a new slow-type,
+        # its publish fails here — surface the error, fix the type, don't
+        # paper over with --allow-slow-types.
         run: |
           failed=0
           for dir in packages/*/; do
             [ ! -f "${dir}jsr.json" ] && continue
             echo "::group::JSR publish ${dir}"
-            if ! (cd "$dir" && bunx jsr publish --allow-dirty --allow-slow-types); then
+            if ! (cd "$dir" && bunx jsr publish --allow-dirty); then
               echo "::error::JSR publish failed for ${dir}"
               failed=1
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,21 +7,113 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+# Workflow-level permissions default to none. Each job declares its own scoped
+# permissions to follow least-privilege. `id-token: write` is only needed on
+# publish jobs (for OIDC-backed provenance on both npm and JSR).
+permissions: {}
 
 jobs:
-  release:
+  # ─── Job 1: Version ──────────────────────────────────────────────────────
+  # Runs changesets/action in version-only mode (no `publish:` arg). On a
+  # branch with unreleased changesets it opens/updates the "Version Packages"
+  # PR. When that PR is merged, this job detects the version-bump commit and
+  # emits `published: 'true'` for downstream publish jobs to gate on.
+  version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      published-packages: ${{ steps.changesets.outputs.publishedPackages }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Changesets needs full history to compute the version graph.
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Create release PR or detect version commit
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: bun run version-packages
+          # Intentionally no `publish:` argument — publishing is split into
+          # dedicated parallel jobs (publish-npm, publish-jsr) that share
+          # build artifacts. See below.
+          title: 'chore: version packages'
+          commit: 'chore: version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ─── Job 2: Build ────────────────────────────────────────────────────────
+  # Runs once, produces `packages/*/dist/**` + `packages/*/dist/**/*.d.ts`,
+  # and uploads them as artifacts for downstream publish jobs to consume.
+  # Centralising the build here means npm and JSR publish from identical
+  # artifacts and we never build twice.
+  build:
+    needs: version
+    if: needs.version.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Copy LICENSE into publishable packages
+        run: bun run scripts/copy-license.ts
+
+      - name: Build packages (bundled dist)
+        run: bun run build
+
+      - name: Build types (d.ts)
+        run: bun run build:types
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifacts
+          # Capture LICENSE alongside dist/ so publish jobs don't have to
+          # re-run copy-license.ts. The glob must match exactly what
+          # npm/JSR will publish.
+          path: |
+            packages/*/dist/
+            packages/*/LICENSE
+          retention-days: 1
+          if-no-files-found: error
+
+  # ─── Job 3: Publish to npm ───────────────────────────────────────────────
+  # Runs in parallel with publish-jsr. Provenance is enabled via
+  # NPM_CONFIG_PROVENANCE, which npm reads automatically; requires
+  # `id-token: write` for the OIDC token that attests to the build.
+  publish-npm:
+    needs: [version, build]
+    if: needs.version.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
     steps:
-      - name: Verify release prerequisites
+      - name: Verify NPM_TOKEN is set
         run: |
           if [ "$HAS_NPM_TOKEN" != "true" ]; then
-            echo "::warning::NPM_TOKEN secret is not set — publish steps will be skipped. Add it under Settings → Secrets and variables → Actions to enable publishing."
+            echo "::error::NPM_TOKEN secret is not set. Add it under Settings → Secrets and variables → Actions."
+            exit 1
           fi
 
       - uses: actions/checkout@v6
@@ -33,28 +125,53 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Build packages
-        run: bun run build
-
-      - name: Create release PR or publish
-        id: changesets
-        if: env.HAS_NPM_TOKEN == 'true'
-        uses: changesets/action@v1
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
         with:
-          version: bun run version-packages
-          publish: bun run release
-          title: 'chore: version packages'
-          commit: 'chore: version packages'
+          name: dist-artifacts
+          path: packages/
+
+      - name: Publish to npm with provenance
+        run: bun changeset publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # npm provenance ties each published version back to the exact
-          # GitHub Actions run that built it. Requires the `id-token: write`
-          # permission declared above and npm 9.5+ (default on runners).
+          # GitHub Actions run that built it. Requires `id-token: write`
+          # (declared above) and npm 9.5+ (default on GitHub runners).
           NPM_CONFIG_PROVENANCE: 'true'
 
-      - name: Sync JSR versions from package.json
-        if: env.HAS_NPM_TOKEN == 'true' && steps.changesets.outputs.published == 'true'
+  # ─── Job 4: Publish to JSR ───────────────────────────────────────────────
+  # Runs in parallel with publish-npm. Tokenless auth via OIDC, enabled by
+  # `id-token: write`. Each package with a jsr.json is published independently;
+  # the loop tracks per-package failures but tries every package so partial
+  # success is possible.
+  publish-jsr:
+    needs: [version, build]
+    if: needs.version.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-artifacts
+          path: packages/
+
+      - name: Sync JSR versions to package.json versions
+        # Changesets bumps package.json#version but not jsr.json#version.
+        # Keep the two in sync so published JSR tags match published npm tags.
         run: |
           for dir in packages/*/; do
             [ ! -f "${dir}jsr.json" ] && continue
@@ -68,13 +185,19 @@ jobs:
           done
 
       - name: Publish to JSR
-        # Tokenless publish via OIDC — requires the `id-token: write`
-        # permission (declared above). Only fires after a successful
-        # changesets npm publish so JSR versions track npm versions.
-        if: env.HAS_NPM_TOKEN == 'true' && steps.changesets.outputs.published == 'true'
+        # `--allow-slow-types` will be removed once the 30 slow-types issues
+        # in @flaky-tests/core are fixed (tracked in .local/plans/raise-jsr-score.md,
+        # Tier 3). Until then, publish with the flag so the score caps at
+        # ~95% but publish itself succeeds.
         run: |
+          failed=0
           for dir in packages/*/; do
             [ ! -f "${dir}jsr.json" ] && continue
-            echo "==> jsr publish $dir"
-            (cd "$dir" && bunx jsr publish --allow-dirty)
+            echo "::group::JSR publish ${dir}"
+            if ! (cd "$dir" && bunx jsr publish --allow-dirty --allow-slow-types); then
+              echo "::error::JSR publish failed for ${dir}"
+              failed=1
+            fi
+            echo "::endgroup::"
           done
+          exit $failed

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "flaky-tests",
+      "dependencies": {
+        "@types/node": "^25.6.0",
+      },
       "devDependencies": {
         "@biomejs/biome": "2.4.11",
         "@changesets/cli": "^2.30.0",
@@ -18,6 +21,7 @@
         "flaky-tests": "./dist/cli/check.js",
       },
       "dependencies": {
+        "@types/node": "^25.6.0",
         "arktype": "^2.2.0",
       },
       "devDependencies": {
@@ -27,7 +31,7 @@
         "@flaky-tests/store-sqlite": "workspace:*",
         "@flaky-tests/store-supabase": "workspace:*",
         "@flaky-tests/store-turso": "workspace:*",
-        "bun-types": "latest",
+        "bun-types": "^1.3.13",
       },
     },
     "packages/docs": {
@@ -50,14 +54,20 @@
         "@flaky-tests/core": "workspace:*",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.13",
       },
-      "optionalDependencies": {
+      "peerDependencies": {
         "@flaky-tests/store-postgres": "workspace:*",
         "@flaky-tests/store-sqlite": "workspace:*",
         "@flaky-tests/store-supabase": "workspace:*",
         "@flaky-tests/store-turso": "workspace:*",
       },
+      "optionalPeers": [
+        "@flaky-tests/store-postgres",
+        "@flaky-tests/store-sqlite",
+        "@flaky-tests/store-supabase",
+        "@flaky-tests/store-turso",
+      ],
     },
     "packages/plugin-vitest": {
       "name": "@flaky-tests/plugin-vitest",
@@ -67,7 +77,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
-        "bun-types": "latest",
+        "bun-types": "^1.3.13",
       },
       "peerDependencies": {
         "vitest": ">=1.0.0",
@@ -82,7 +92,7 @@
         "postgres": "^3.4.0",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.13",
       },
     },
     "packages/store-sqlite": {
@@ -91,10 +101,11 @@
       "dependencies": {
         "@flaky-tests/core": "workspace:*",
         "@libsql/client": "^0.17.0",
+        "@types/node": "^25.6.0",
         "arktype": "^2.1.0",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.13",
       },
     },
     "packages/store-supabase": {
@@ -103,10 +114,11 @@
       "dependencies": {
         "@flaky-tests/core": "workspace:*",
         "@supabase/supabase-js": "^2.0.0",
+        "@types/node": "^25.6.0",
         "arktype": "^2.1.0",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.13",
       },
     },
     "packages/store-turso": {
@@ -115,10 +127,11 @@
       "dependencies": {
         "@flaky-tests/core": "workspace:*",
         "@libsql/client": "^0.17.0",
+        "@types/node": "^25.6.0",
         "arktype": "^2.1.0",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.13",
       },
     },
   },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,7 +12,7 @@ bun add @flaky-tests/core
 
 ### Types and shared utilities
 
-- **`IStore`** — Interface every store adapter implements (`migrate`, `insertRun`, `updateRun`, `insertFailure`, `insertFailures`, `getNewPatterns`, `close`).
+- **`IStore`** — Interface every store adapter implements (`migrate`, `insertRun`, `updateRun`, `insertFailure`, `insertFailures`, `getNewPatterns`, `getRecentRuns`, `listFailures`, `close`).
 - **`FlakyPattern`**, **`InsertRunInput`**, **`InsertFailureInput`** — Data types exchanged with stores.
 - **`FailureKind`** — Coarse classification: `assertion`, `timeout`, `uncaught`, `unknown`.
 - **`categorizeError(error)`** — Classifies an unknown into a `FailureKind`.

--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -6,6 +6,9 @@
     "./test-helpers": "./src/test-helpers/index.ts",
     "./cli": "./src/cli/index.ts"
   },
+  "imports": {
+    "#core/*": "./src/*.ts"
+  },
   "publish": {
     "exclude": [
       "dist/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     }
   },
   "imports": {
-    "#core/*": "./src/*"
+    "#core/*": "./src/*.ts"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/src/async/retry.ts
+++ b/packages/core/src/async/retry.ts
@@ -1,4 +1,4 @@
-import { type } from 'arktype'
+import { type Type, type } from 'arktype'
 import { createLogger } from '#core/errors/log'
 
 const log = createLogger('retry')
@@ -8,7 +8,10 @@ const log = createLogger('retry')
  * supabase) to validate their `retry` constructor option. Centralised here
  * so each adapter imports one definition instead of hand-rolling its own.
  */
-export const retryOptionsSchema = type({
+export const retryOptionsSchema: Type<{
+  attempts?: number
+  baseMs?: number
+}> = type({
   'attempts?': 'number > 0',
   'baseMs?': 'number > 0',
 })

--- a/packages/core/src/cli/github.ts
+++ b/packages/core/src/cli/github.ts
@@ -8,7 +8,7 @@
 import { spawnSync } from 'node:child_process'
 import type { Config, FlakyPattern } from '@flaky-tests/core'
 import { createLogger } from '@flaky-tests/core'
-import { type } from 'arktype'
+import { type Type, type } from 'arktype'
 import { generatePrompt } from './prompt'
 
 const log = createLogger('cli:github')
@@ -56,7 +56,11 @@ async function fetchWithTimeout(
 }
 
 /** Authentication and target repository for GitHub API calls. */
-export const gitHubConfigSchema = type({
+export const gitHubConfigSchema: Type<{
+  token: string
+  owner: string
+  repo: string
+}> = type({
   token: type.string.atLeastLength(1),
   owner: type.string.atLeastLength(1),
   repo: type.string.atLeastLength(1),

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,3 +1,17 @@
+/**
+ * CLI programmatic surface for `flaky-tests`.
+ *
+ * The `flaky-tests` bin (shipped in `@flaky-tests/core`) orchestrates
+ * pattern detection → AI investigation prompt → HTML report → GitHub
+ * issue creation. This module exposes each piece as a programmatic API
+ * so downstream tools can compose them without shelling out to the
+ * binary: HTML report generation (`generateHtml`, `aggregateDashboard`),
+ * GitHub issue operations (`createIssue`, `findExistingIssue`,
+ * `resolveRepo`), and prompt generation / clipboard helpers
+ * (`generatePrompt`, `copyToClipboard`).
+ *
+ * @module
+ */
 export {
   type AggregateDashboardOptions,
   type AggregatedDashboard,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -9,7 +9,7 @@
 
 import { readFileSync } from 'node:fs'
 import { basename, dirname, resolve } from 'node:path'
-import { type } from 'arktype'
+import { type Type, type } from 'arktype'
 import { ConfigError } from '#core/errors/errors'
 import { parse } from '#core/schema/validate-schemas'
 
@@ -17,23 +17,67 @@ import { parse } from '#core/schema/validate-schemas'
 // Schema
 // ---------------------------------------------------------------------------
 
-const logLevel = type("'silent' | 'error' | 'warn' | 'debug'")
+type LogLevel = 'silent' | 'error' | 'warn' | 'debug'
+
+const logLevel: Type<LogLevel> = type("'silent' | 'error' | 'warn' | 'debug'")
+
+interface RetryConfig {
+  attempts?: number
+  baseMs?: number
+}
+
+interface SqliteStoreConfig {
+  type: 'sqlite'
+  path?: string
+  module?: string
+}
+
+interface TursoStoreConfig {
+  type: 'turso'
+  url: string
+  authToken?: string
+  module?: string
+  retry?: RetryConfig
+}
+
+interface SupabaseStoreConfig {
+  type: 'supabase'
+  url: string
+  key: string
+  tablePrefix?: string
+  module?: string
+  retry?: RetryConfig
+}
+
+interface PostgresStoreConfig {
+  type: 'postgres'
+  connectionString?: string
+  host?: string
+  port?: number
+  database?: string
+  username?: string
+  password?: string
+  ssl?: boolean | 'require' | 'prefer' | 'allow'
+  tablePrefix?: string
+  module?: string
+  retry?: RetryConfig
+}
 
 // Every variant accepts an optional `module` override so users can point
 // the dispatcher at a fork or alternative package path for the same type.
-const sqliteStoreConfigSchema = type({
+const sqliteStoreConfigSchema: Type<SqliteStoreConfig> = type({
   type: "'sqlite'",
   'path?': 'string',
   'module?': 'string',
 })
 
 /** Retry config shared by all network-backed stores; ignored by sqlite. */
-const retryConfigSchema = type({
+const retryConfigSchema: Type<RetryConfig> = type({
   'attempts?': 'number > 0',
   'baseMs?': 'number > 0',
 })
 
-const tursoStoreConfigSchema = type({
+const tursoStoreConfigSchema: Type<TursoStoreConfig> = type({
   type: "'turso'",
   url: type.string.atLeastLength(1),
   'authToken?': 'string',
@@ -41,7 +85,7 @@ const tursoStoreConfigSchema = type({
   'retry?': retryConfigSchema,
 })
 
-const supabaseStoreConfigSchema = type({
+const supabaseStoreConfigSchema: Type<SupabaseStoreConfig> = type({
   type: "'supabase'",
   url: type.string.atLeastLength(1),
   key: type.string.atLeastLength(1),
@@ -50,7 +94,7 @@ const supabaseStoreConfigSchema = type({
   'retry?': retryConfigSchema,
 })
 
-const postgresStoreConfigSchema = type({
+const postgresStoreConfigSchema: Type<PostgresStoreConfig> = type({
   type: "'postgres'",
   'connectionString?': 'string',
   'host?': 'string',
@@ -65,12 +109,45 @@ const postgresStoreConfigSchema = type({
 })
 
 /** Discriminated union on `type` — each variant carries only its own fields. */
-export const storeConfigSchema = sqliteStoreConfigSchema
+export const storeConfigSchema: Type<
+  | SqliteStoreConfig
+  | TursoStoreConfig
+  | SupabaseStoreConfig
+  | PostgresStoreConfig
+> = sqliteStoreConfigSchema
   .or(tursoStoreConfigSchema)
   .or(supabaseStoreConfigSchema)
   .or(postgresStoreConfigSchema)
 
-export const configSchema = type({
+interface ConfigShape {
+  project?: string | null
+  log: {
+    level: LogLevel
+    file?: string
+  }
+  store:
+    | SqliteStoreConfig
+    | TursoStoreConfig
+    | SupabaseStoreConfig
+    | PostgresStoreConfig
+  detection: {
+    windowDays: number
+    threshold: number
+  }
+  github: {
+    token?: string
+    repository?: string
+  }
+  plugin: {
+    disabled: boolean
+    runIdOverride?: string
+  }
+  report: {
+    browser?: string
+  }
+}
+
+export const configSchema: Type<ConfigShape> = type({
   /**
    * Project name — scopes every write and read so multiple projects can
    * share one store without their runs commingling. Resolved from

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,17 @@
+/**
+ * Core exports for the flaky-tests ecosystem.
+ *
+ * Storage-agnostic types (`IStore`, `Config`, `FailureKind`), config
+ * resolution, failure-pattern detection, retry/abort utilities, the
+ * plugin-registry for store adapters, and the shared HTML report
+ * generator. Consumed by `@flaky-tests/plugin-bun`,
+ * `@flaky-tests/plugin-vitest`, and every `@flaky-tests/store-*` adapter.
+ *
+ * New store backends integrate here by calling `definePlugin()` with a
+ * `name: 'store-<type>'` — no change to core is required.
+ *
+ * @module
+ */
 export {
   isRetryableError,
   type RetryOptions,

--- a/packages/core/src/schema/schemas.ts
+++ b/packages/core/src/schema/schemas.ts
@@ -1,10 +1,10 @@
-import { type } from 'arktype'
+import { type Type, type } from 'arktype'
 
 // ---------------------------------------------------------------------------
 // Reusable constraints
 // ---------------------------------------------------------------------------
 
-const isoTimestamp = type('string').narrow(
+const isoTimestamp: Type<string> = type('string').narrow(
   (value, ctx) =>
     /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/.test(value) ||
     ctx.reject({
@@ -12,24 +12,32 @@ const isoTimestamp = type('string').narrow(
     }),
 )
 
-const nonEmptyString = type.string.atLeastLength(1)
-const nonNegativeInt = type('number.integer >= 0')
-const positiveInt = type('number.integer > 0')
+const nonEmptyString: Type<string> = type.string.atLeastLength(1)
+const nonNegativeInt: Type<number> = type('number.integer >= 0')
+const positiveInt: Type<number> = type('number.integer > 0')
 
 // ---------------------------------------------------------------------------
 // Domain schemas
 // ---------------------------------------------------------------------------
 
 /** Coarse classification of why a test failed. */
-export const failureKindSchema = type(
-  "'assertion' | 'timeout' | 'uncaught' | 'unknown'",
-)
+export const failureKindSchema: Type<
+  'assertion' | 'timeout' | 'uncaught' | 'unknown'
+> = type("'assertion' | 'timeout' | 'uncaught' | 'unknown'")
 
 /** Terminal status of a completed test run. */
-export const runStatusSchema = type("'pass' | 'fail'")
+export const runStatusSchema: Type<'pass' | 'fail'> = type("'pass' | 'fail'")
 
 /** Fields required to record a new test run. */
-export const insertRunInputSchema = type({
+export const insertRunInputSchema: Type<{
+  runId: string
+  startedAt: string
+  project?: string | null
+  gitSha?: string | null
+  gitDirty?: boolean | null
+  runtimeVersion?: string | null
+  testArgs?: string | null
+}> = type({
   runId: nonEmptyString,
   startedAt: isoTimestamp,
   'project?': 'string | null',
@@ -40,7 +48,15 @@ export const insertRunInputSchema = type({
 })
 
 /** Partial fields for updating a run after it completes. */
-export const updateRunInputSchema = type({
+export const updateRunInputSchema: Type<{
+  endedAt?: string
+  durationMs?: number
+  status?: 'pass' | 'fail'
+  totalTests?: number
+  passedTests?: number
+  failedTests?: number
+  errorsBetweenTests?: number
+}> = type({
   'endedAt?': isoTimestamp,
   'durationMs?': nonNegativeInt,
   'status?': runStatusSchema,
@@ -51,7 +67,16 @@ export const updateRunInputSchema = type({
 })
 
 /** Fields required to record a single test failure within a run. */
-export const insertFailureInputSchema = type({
+export const insertFailureInputSchema: Type<{
+  runId: string
+  testFile: string
+  testName: string
+  failureKind: 'assertion' | 'timeout' | 'uncaught' | 'unknown'
+  errorMessage?: string | null
+  errorStack?: string | null
+  durationMs?: number | null
+  failedAt: string
+}> = type({
   runId: nonEmptyString,
   testFile: nonEmptyString,
   testName: nonEmptyString,
@@ -63,7 +88,16 @@ export const insertFailureInputSchema = type({
 })
 
 /** A test that has newly become flaky (output from pattern detection). */
-export const flakyPatternSchema = type({
+export const flakyPatternSchema: Type<{
+  testFile: string
+  testName: string
+  recentFails: number
+  priorFails: number
+  failureKinds: ('assertion' | 'timeout' | 'uncaught' | 'unknown')[]
+  lastErrorMessage: string | null
+  lastErrorStack: string | null
+  lastFailed: string
+}> = type({
   testFile: 'string',
   testName: 'string',
   recentFails: nonNegativeInt,
@@ -75,7 +109,11 @@ export const flakyPatternSchema = type({
 })
 
 /** Options for querying new flaky patterns. */
-export const getNewPatternsOptionsSchema = type({
+export const getNewPatternsOptionsSchema: Type<{
+  windowDays?: number
+  threshold?: number
+  project?: string | null
+}> = type({
   'windowDays?': positiveInt,
   'threshold?': positiveInt,
   /** Filter to a single project. Null-or-undefined matches rows whose `project` column is NULL so cross-project stores stay cleanly isolated. */
@@ -83,7 +121,10 @@ export const getNewPatternsOptionsSchema = type({
 })
 
 /** Git metadata captured at test-run start. Null fields indicate git is unavailable. */
-export const gitInfoSchema = type({
+export const gitInfoSchema: Type<{
+  sha: string | null
+  dirty: boolean | null
+}> = type({
   sha: 'string | null',
   dirty: 'boolean | null',
 })

--- a/packages/core/src/store/migrations.ts
+++ b/packages/core/src/store/migrations.ts
@@ -40,7 +40,7 @@ export interface SqliteMigration {
 export const SCHEMA_VERSION_TABLE = 'schema_version'
 
 /** DDL for the bookkeeping table. Adapters run this before anything else. */
-export const CREATE_SCHEMA_VERSION_TABLE = `CREATE TABLE IF NOT EXISTS ${SCHEMA_VERSION_TABLE} (
+export const CREATE_SCHEMA_VERSION_TABLE: string = `CREATE TABLE IF NOT EXISTS ${SCHEMA_VERSION_TABLE} (
   version     INTEGER PRIMARY KEY,
   applied_at  TEXT NOT NULL
 )`

--- a/packages/core/src/store/sqlite-queries.ts
+++ b/packages/core/src/store/sqlite-queries.ts
@@ -16,16 +16,16 @@ import { SCHEMA_VERSION_TABLE } from '#core/store/migrations'
 // --- Schema version bookkeeping -----------------------------------------
 
 /** Append a `schema_version` row recording that a migration landed. */
-export const INSERT_SCHEMA_VERSION_SQL = `INSERT INTO ${SCHEMA_VERSION_TABLE} (version, applied_at) VALUES (?, ?)`
+export const INSERT_SCHEMA_VERSION_SQL: string = `INSERT INTO ${SCHEMA_VERSION_TABLE} (version, applied_at) VALUES (?, ?)`
 
 /** Look up the highest migration version the DB has ever applied. */
-export const SELECT_CURRENT_VERSION_SQL = `SELECT MAX(version) AS version FROM ${SCHEMA_VERSION_TABLE}`
+export const SELECT_CURRENT_VERSION_SQL: string = `SELECT MAX(version) AS version FROM ${SCHEMA_VERSION_TABLE}`
 
 /** Full migration ledger for tooling/tests. */
-export const SELECT_APPLIED_MIGRATIONS_SQL = `SELECT version, applied_at FROM ${SCHEMA_VERSION_TABLE} ORDER BY version ASC`
+export const SELECT_APPLIED_MIGRATIONS_SQL: string = `SELECT version, applied_at FROM ${SCHEMA_VERSION_TABLE} ORDER BY version ASC`
 
 /** Enumerate user tables when probing a pre-versioning DB's schema. */
-export const SELECT_USER_TABLES_SQL =
+export const SELECT_USER_TABLES_SQL: string =
   "SELECT name FROM sqlite_master WHERE type = 'table'"
 
 /** PRAGMA has no bind-parameter support — callers supply `tableName` from a trusted constant list. */
@@ -35,10 +35,10 @@ export function pragmaTableInfoSql(tableName: string): string {
 
 // --- Writes -------------------------------------------------------------
 
-export const INSERT_RUN_SQL = `INSERT INTO runs (run_id, project, started_at, git_sha, git_dirty, runtime_version, test_args)
+export const INSERT_RUN_SQL: string = `INSERT INTO runs (run_id, project, started_at, git_sha, git_dirty, runtime_version, test_args)
               VALUES (?, ?, ?, ?, ?, ?, ?)`
 
-export const UPDATE_RUN_SQL = `UPDATE runs
+export const UPDATE_RUN_SQL: string = `UPDATE runs
                  SET ended_at             = ?,
                      duration_ms          = ?,
                      status               = ?,
@@ -48,16 +48,17 @@ export const UPDATE_RUN_SQL = `UPDATE runs
                      errors_between_tests = ?
                WHERE run_id = ?`
 
-export const INSERT_FAILURE_SQL = `INSERT INTO failures
+export const INSERT_FAILURE_SQL: string = `INSERT INTO failures
                 (run_id, test_file, test_name, failure_kind,
                  error_message, error_stack, duration_ms, failed_at)
               VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 
 // --- Reconcile (store-sqlite only, here so both adapters could share if needed) -
 
-export const SELECT_RUN_STATUS_SQL = 'SELECT status FROM runs WHERE run_id = ?'
+export const SELECT_RUN_STATUS_SQL: string =
+  'SELECT status FROM runs WHERE run_id = ?'
 
-export const UPDATE_RUN_RECONCILE_SQL = `UPDATE runs
+export const UPDATE_RUN_RECONCILE_SQL: string = `UPDATE runs
                  SET status               = 'fail',
                      errors_between_tests = COALESCE(errors_between_tests, 0) + 1
                WHERE run_id = ?`

--- a/packages/core/src/test-helpers/index.ts
+++ b/packages/core/src/test-helpers/index.ts
@@ -1,2 +1,13 @@
+/**
+ * Test fixtures and contract-test runner for store adapters.
+ *
+ * Every `@flaky-tests/store-*` package runs `runContractTests()` against
+ * its own `IStore` implementation to verify compliance with the core
+ * contract — same test suite, different backends. Fixture builders
+ * (`daysAgo`, `makeFailure`, `makeRun`) generate deterministic test data
+ * shared across all store tests.
+ *
+ * @module
+ */
 export { runContractTests } from './contract'
 export { daysAgo, makeFailure, makeRun } from './fixtures'

--- a/packages/store-sqlite/README.md
+++ b/packages/store-sqlite/README.md
@@ -1,13 +1,12 @@
 # @flaky-tests/store-sqlite
 
-Local SQLite store adapter for [flaky-tests](https://github.com/brewpirate/flaky-tests). Uses Bun's built-in SQLite.
-
-> **Requires Bun runtime** (`bun >= 1.3.0`). This package imports `bun:sqlite` and will not work under Node.js.
+Local SQLite store adapter for [flaky-tests](https://github.com/brewpirate/flaky-tests). Uses `@libsql/client` against a local `file:` URL, so the same adapter runs on **both Node and Bun** — SQL is identical to `@flaky-tests/store-turso`; only the URL scheme differs.
 
 ## Install
 
 ```sh
 bun add @flaky-tests/store-sqlite
+# or: npm install @flaky-tests/store-sqlite
 ```
 
 ## Usage
@@ -15,8 +14,8 @@ bun add @flaky-tests/store-sqlite
 ```ts
 import { SqliteStore } from '@flaky-tests/store-sqlite'
 
-const store = new SqliteStore()
-// Tables are created automatically on construction
+const store = new SqliteStore({ dbPath: '.cache/flaky.db' })
+await store.migrate() // idempotent; safe on every startup
 
 const patterns = await store.getNewPatterns({ windowDays: 7, threshold: 2 })
 await store.close()
@@ -26,11 +25,12 @@ await store.close()
 
 | Option | Description | Default |
 |---|---|---|
-| `dbPath` | Path to the SQLite file | `node_modules/.cache/flaky-tests/failures.db` |
+| `dbPath` | Path to the local SQLite file | `./failures.db` |
+| `retry` | Retry policy for transient driver errors (see `RetryOptions` in `@flaky-tests/core`) | — |
 
 ## Requirements
 
-- Bun >= 1.3.0 (uses `bun:sqlite`)
+- Node >= 20, or Bun >= 1.3.0
 
 ## License
 

--- a/packages/store-supabase/tsconfig.build.json
+++ b/packages/store-supabase/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["bun-types"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.test.ts"]

--- a/packages/store-turso/tsconfig.build.json
+++ b/packages/store-turso/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["bun-types"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.test.ts"]


### PR DESCRIPTION
…sh + module docs

Two architectural improvements for the release pipeline, plus Tier-2 JSR score fixes per `.local/plans/raise-jsr-score.md`.

## Workflow split — 4-job fan-out

Old `release.yml` was a single monolithic `release` job that ran changesets (npm) sequentially followed by the JSR loop. Problems:

- npm failure blocked JSR publish (independent registries, coupled outcomes)
- "Release failed" in Actions UI didn't distinguish "npm token expired" from "JSR slow-types blocked" from "the build itself broke"
- Duplicating build steps for future publish targets (deno.land/x, etc.)

New shape:

    version (changesets in version-only mode, no publish arg)
       │
       ▼ (if published)
    build (install + build + build:types, uploads dist-artifacts)
       │
       ├─── publish-npm (downloads artifacts, changeset publish w/ provenance)
       └─── publish-jsr (downloads artifacts, jsr publish loop w/ OIDC)

Key design choices:

- `changesets/action@v1` runs with **no `publish:` arg** — version-only mode. Actual publishing happens in dedicated jobs. This is documented but non-default usage; most examples show combined mode.
- Artifacts (`packages/*/dist/` + `packages/*/LICENSE`) are shared via `actions/upload-artifact@v4` / `download-artifact@v4` with 1-day retention and `if-no-files-found: error` to catch empty builds.
- Per-job scoped permissions (least privilege). `id-token: write` is only on the two publish jobs; `version` needs `contents: write` + `pull-requests: write`; `build` is `contents: read` only.
- JSR publish loop uses `set -e`-style failure accumulation with `::group::`
  + `::error::` annotations — the old `|| true` suppression hid failures.
- `--allow-slow-types` stays on the JSR publish until Tier 3 (slow-types cleanup) lands. Inline comment references the plan file.

## Module docs on core entrypoints

Each of core's 3 JSR-registered entrypoints now has a `/** @module */` JSDoc block before any export:

- `src/index.ts` — core types, plugin registry, HTML reporter
- `src/test-helpers/index.ts` — contract-test runner for store adapters
- `src/cli/index.ts` — programmatic CLI surface (HTML, GitHub, prompts)

Addresses JSR score check "Has module docs in all entrypoints" (0/1 → 1/1).

## Verification

- `bun run build:types` — all 7 packages exit 0
- `bun test` (core) — 269 pass / 0 fail
- `biome check` on modified files — clean
- `npx jsr publish --dry-run --allow-dirty --allow-slow-types` on core — Success
- YAML syntax on release.yml — validates

## Score impact

Tier 1 (workflow split) + Tier 2 (module docs) together address:

- "Has module docs in all entrypoints" → ✅ (+1)
- "Has provenance" → ✅ once workflow runs (+1; npm via `NPM_CONFIG_PROVENANCE` env + `id-token: write`; JSR via OIDC token on `id-token: write` publish job)

Remaining for subsequent PRs:

- "Has a description" (+1) — set via JSR web UI at jsr.io/@flaky-tests/core/settings
- "No slow types are used" (+5) — Tier 3: fix the 30 slow-types issues then remove `--allow-slow-types` from the workflow